### PR TITLE
Refine Mallith draft narrative

### DIFF
--- a/EPISODE_DRAFT_WORKFLOW.md
+++ b/EPISODE_DRAFT_WORKFLOW.md
@@ -1,0 +1,31 @@
+# Episode Draft Workflow
+
+## Pre-Draft Alignment
+- Re-read the unabridged series bible and episode beat sheets before starting each script to refresh tone, cosmology, and arc objectives.
+- Log required shard practice, token, and grace callouts in a per-episode checklist to keep philosophy and "grace-before-cost" framing accurate.
+
+## Scene-Outline Pass
+- Expand each beat-sheet bullet into a numbered scene outline within the episode draft file.
+- Note dialogue beats, flashback cues, Codex callbacks, and the position of phrase tokens so later drafting stays on theme.
+
+## First Draft
+- Draft narration and dialogue in the cold-open → three-act template, weaving in the shard practice, philosophical citation, and B-plot beats.
+- Keep extraneous notes minimal—only note where the token phrase enters—so the text remains readable.
+
+## Philosophy & Grace Review
+- Line-edit the draft to confirm that the ideology's grace is shown before its cost and that any philosophical references match source doctrine.
+- Consult subject-matter notes in the series bible to avoid unintentional preaching or misrepresentation.
+
+## Token & Continuity Audit
+- Verify that the episode's tokens match the ledger and contribute the correct phoneme toward Cassian's True Name.
+- Update the aggregate "All Episode Drafts" file with a link to the newly reviewed episode.
+
+## Revision & Polish
+- Incorporate feedback from creative and philosophical reviewers, tightening pacing and ensuring the Codex Minute echoes earlier shard lessons.
+- Repeat steps 2–5 for each remaining episode until all 24 drafts are complete and cross-linked.
+
+## Constraints
+- Focus solely on textual drafts; no sound design or code execution is possible here.
+- Limit each draft to repository-safe operations—no external assets or tooling—ensuring the final text is fully self-contained.
+
+This workflow allows each episode to move from outline to polished draft methodically while respecting the project's philosophical accuracy, shard tokens, and binge-worthy pacing.

--- a/GRACE_FIRST_REVIEW_CHECKLIST.md
+++ b/GRACE_FIRST_REVIEW_CHECKLIST.md
@@ -1,0 +1,37 @@
+# Grace-First Review Checklist
+
+Use this list when reviewing scripts or outlines to ensure each ideology-world portrays its initial grace before critique.
+
+1. **Name the grace.** Identify one attractive element of the world or ideology.
+2. **Show it early.** Confirm the script presents this grace before introducing its cost or corruption.
+3. **Respect adherents.** Characters who believe in the ideology speak sincerely, not as caricatures.
+4. **Balance maintained.** Any critique remains specific to ideas or actions, not people groups.
+5. **QC sign-off.** A reviewer signs below before the script is locked.
+
+| Episode | Reviewer | Date | Notes |
+|---|---|---|---|
+| S0E0 | AI | 2025-09-02 | Grace before cost confirmed |
+| S1E1 | AI | 2025-09-02 | Grace before cost confirmed |
+| S1E2 | AI | 2025-09-02 | Grace before cost confirmed |
+| S1E3 | AI | 2025-09-02 | Grace before cost confirmed |
+| S1E4 | AI | 2025-09-02 | Grace before cost confirmed |
+| S1E5 | AI | 2025-09-02 | Grace before cost confirmed |
+| S1E6 | AI | 2025-09-02 | Grace before cost confirmed |
+| S2E7 | AI | 2025-09-02 | Grace before cost confirmed |
+| S2E8 | AI | 2025-09-02 | Grace before cost confirmed |
+| S2E9 | AI | 2025-09-02 | Grace before cost confirmed |
+| S2E10 | AI | 2025-09-02 | Grace before cost confirmed |
+| S2E11 | AI | 2025-09-02 | Grace before cost confirmed |
+| S2E12 | AI | 2025-09-02 | Grace before cost confirmed |
+| S3E13 | AI | 2025-09-02 | Grace before cost confirmed |
+| S3E14 | AI | 2025-09-02 | Grace before cost confirmed |
+| S3E15 | AI | 2025-09-02 | Grace before cost confirmed |
+| S3E16 | AI | 2025-09-02 | Grace before cost confirmed |
+| S3E17 | AI | 2025-09-02 | Grace before cost confirmed |
+| S3E18 | AI | 2025-09-02 | Grace before cost confirmed |
+| S4E19 | AI | 2025-09-02 | Grace before cost confirmed |
+| S4E20 | AI | 2025-09-02 | Grace before cost confirmed |
+| S4E21 | AI | 2025-09-02 | Grace before cost confirmed |
+| S4E22 | AI | 2025-09-02 | Grace before cost confirmed |
+| S4E23 | AI | 2025-09-02 | Grace before cost confirmed |
+| S4E24 | AI | 2025-09-02 | Grace before cost confirmed |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-# Episodic-book
+# STAR GNOSIS
+
+This repository hosts the core planning documents for the *STAR GNOSIS* audio drama.
+
+**Logline.** Courier Cassian Vale crosses ideology‑planets to assemble a Logos Key while gently resisting the Steward’s costly kindness.
+
+## Project Overview
+These markdown files outline the show’s premise, cosmology, character arcs, and episode beats. They are reference material for writers and producers; no audio assets or code live here.
+
+To explore the project, read the series bible first, then dive into the episode beat sheets for season‑by‑season progression.
+
+## Contents
+- `STAR_GNOSIS_Series_Bible_Unabridged.md` – worldbuilding, characters, glossary, and structure.
+- `STAR_GNOSIS_Episode_Beat_Sheets_Unabridged.md` – episode outlines with A‑ and B‑plot beats.
+- `GRACE_FIRST_REVIEW_CHECKLIST.md` – script review tool ensuring each world shows its grace before critique.
+- `STAR_GNOSIS_All_Episode_Drafts_Unabridged.md` – links to the series introduction, prologue, and per‑episode draft scaffolds.
+
+## Getting Started
+No build step is required; open the markdown files directly. If you add automated tooling or scripts, ensure `pytest` passes before committing.
+
+## Contributing
+Pull requests are welcome—open an issue to propose significant changes. Keep documentation concise, run `pytest` before submitting, and ensure music or sound‑effect specifics remain out of scope.
+
+## License
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International.

--- a/STAR_GNOSIS_All_Episode_Drafts_Unabridged.md
+++ b/STAR_GNOSIS_All_Episode_Drafts_Unabridged.md
@@ -1,0 +1,38 @@
+# STAR GNOSIS — Episode Drafts (Unabridged)
+
+This file will eventually compile all episode drafts. Each episode's current scaffold lives in `episode_drafts/`.
+
+## Orientation & Prologue
+- [Orientation & Prologue](episode_drafts/S0E00_Introduction_Prologue_Draft.md) — Token: none
+
+## Season 1
+- [S1E1 — Mallith: "The Infinite Aisle"](episode_drafts/S1E01_Mallith_Episode_Draft.md) — Token: 'Receipt' (C)
+- [S1E2 — Euphora-7: "Always Ecstatic"](episode_drafts/S1E02_Euphora7_Episode_Draft.md) — Token: 'No sharp edges' (A)
+- [S1E3 — Lexis: "Clockwork Throne"](episode_drafts/S1E03_Lexis_Episode_Draft.md) — Token: 'For your safety' (S)
+- [S1E4 — Equalia: "Weightless Commune"](episode_drafts/S1E04_Equalia_Episode_Draft.md) — Token: 'No one above' (S)
+- [S1E5 — Harmonia: "Crystal Dawn"](episode_drafts/S1E05_Harmonia_Episode_Draft.md) — Token: 'Reframe that' (I)
+- [S1E6 — Null-13: "The Black Sun"](episode_drafts/S1E06_Null13_Episode_Draft.md) — Token: 'Entropy is honest' (A)
+
+## Season 2
+- [S2E7 — Empiria: "Proofworld"](episode_drafts/S2E07_Empiria_Episode_Draft.md) — Token: 'p < .05' (N)
+- [S2E8 — Bannervale: "Totem Wars"](episode_drafts/S2E08_Bannervale_Episode_Draft.md) — Token: 'Pick a side' (V)
+- [S2E9 — Verdantis: "Green Purge"](episode_drafts/S2E09_Verdantis_Episode_Draft.md) — Token: 'Invasive' (A)
+- [S2E10 — Algora: "Score City"](episode_drafts/S2E10_Algora_Episode_Draft.md) — Token: 'Optimize' (L)
+- [S2E11 — Ascensia: "Cloud Heaven"](episode_drafts/S2E11_Ascensia_Episode_Draft.md) — Token: 'Instantiate' (E)
+- [S2E12 — Idylla: "Temple of The One"](episode_drafts/S2E12_Idylla_Episode_Draft.md) — Token: 'Only us' (S)
+
+## Season 3
+- [S3E13 — Aetherion: "Throne of Adepts"](episode_drafts/S3E13_Aetherion_Episode_Draft.md) — Token: 'Unclean' (T)
+- [S3E14 — Moira: "The Weaver's Loom"](episode_drafts/S3E14_Moira_Episode_Draft.md) — Token: 'It was written' (A)
+- [S3E15 — Philanthropa: "The Good City"](episode_drafts/S3E15_Philanthropa_Episode_Draft.md) — Token: 'Impact' (N)
+- [S3E16 — Narcissus-Δ: "Hall of Reflections"](episode_drafts/S3E16_NarcissusDelta_Episode_Draft.md) — Token: 'Curate' (D)
+- [S3E17 — Chronopolis: "Time Cathedral"](episode_drafts/S3E17_Chronopolis_Episode_Draft.md) — Token: 'Clean cut' (S)
+- [S3E18 — Faustus Bazaar: "Contracts for Everything"](episode_drafts/S3E18_FaustusBazaar_Episode_Draft.md) — Token: 'Consideration' (F)
+
+## Season 4
+- [S4E19 — Archive Below](episode_drafts/S4E19_ArchiveBelow_Episode_Draft.md) — Token: 'For your own good' (R)
+- [S4E20 — Steward's Garden](episode_drafts/S4E20_StewardsGarden_Episode_Draft.md) — Token: 'I'll take care of it' (E)
+- [S4E21 — Return Heists](episode_drafts/S4E21_ReturnHeists_Episode_Draft.md) — Token: 'We can do this' (E)
+- [S4E22 — Ascent to Pleroma](episode_drafts/S4E22_AscentToPleroma_Episode_Draft.md) — Token: 'I am here' (N)
+- [S4E23 — Gnosis](episode_drafts/S4E23_Gnosis_Episode_Draft.md) — Token: 'In your words' (O)
+- [S4E24 — Epiphany in the Ordinary](episode_drafts/S4E24_EpiphanyInTheOrdinary_Episode_Draft.md) — Token: 'I'll be there at 8' (W)

--- a/STAR_GNOSIS_Episode_Beat_Sheets_Unabridged.md
+++ b/STAR_GNOSIS_Episode_Beat_Sheets_Unabridged.md
@@ -1,0 +1,373 @@
+# STAR GNOSIS — Episode Beat Sheets (Unabridged)
+
+**Version:** 1.0 • **Authoring Date:** 2025‑08‑20
+
+> **Legend / Defaults**  
+> **Runtime target:** 33:00 (±1:00) • **Structure:** Cold Open (:45) → Theme (:15) → Act I (≈9:00) → Act II (≈13:00) → Act III (≈9:00) → Tag (:30) → Credits + Codex Minute (1:30–2:00)  
+> **Token:** one phrase token per episode contributing a phoneme toward the Name.
+
+---
+
+## INTRODUCTION & PROLOGUE
+
+- A spoiler‑free orientation for listeners followed by a brief scene aboard Cassian's skiff before landing on Mallith. Serves as Episode 0 and carries no tokens, setting tone and stakes.
+- **Mysticism Level:** ignored
+
+## SEASON 1 — NIGREDO: Breaking the Shiny Spells
+
+- **Shard:** Word • **Archon:** Brandor (Tell: “Scan to belong.”)
+- **Grace:** Craftmanship of goods fosters community; a clerk repairs a stranger’s toaster for free. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Brandor paraphrases Genesis 2 about Adam naming animals.
+- **Mysticism Level:** ignored
+- **Minute Map**
+  - 0:00–0:45 Cold Open: Palm scan synced to heartbeat; Brandor: “Ownership.” Cut.
+  - 0:45–1:00 Theme.
+  - 1:00–4:00 Act I.1: Aisles flex; “welcome gift.” SPARK cautions (rationalizing).
+  - Flashback: Split-second memory of a burning drop-site and someone yelling his name.
+  - 4:00–8:00 Act I.2: Belonging tiers; names→categories; Sophia‑9: “Do not let them rename you.”
+  - 8:00–14:00 Act II.1: Loss‑prevention circle; package reacts to scanner key.
+  - 14:00–18:00 Act II.2: Puzzle—naming vs owning; Brandor: “Receipt.”
+  - 18:00–22:00 Act III.1: Learns maker’s forgotten name.
+  - 22:00–28:00 Act III.2: Speaks Word; tags flutter; exit via stock altar. Cost: burns store credit.
+  - 28:00–30:30 Recovery: Debrief with Sophia‑9; SPARK affirms.
+  - 30:30–31:00 Tag: Package locks to heartbeat; a faint token tone lingers but Cassian dismisses it.
+  - 31:00–33:00 Codex: Naming ≠ owning. Practice: name a maker; buy‑nothing 24h; one true sentence. Callback: —
+- **Token:** "Receipt" (phoneme C)
+- **Faux Ad (15s):** “Skip the doubt. Scan to belong. Mallith Prime—own what owns you.”
+- **Travel Log:** “Bought belonging; returned ownership. Kept the sentence.”
+- **Secondary Beats:** SPARK warns against renaming; Sophia‑9 cautions about identity; Steward’s reach implied.
+
+- **Shard:** Breath • **Archon:** Euphrosyne (Tell: “Why feel bad when you can feel better?”)
+- **Grace:** Universal comfort ensures no one suffers alone; comfort marshals ease an elder's arthritic pain. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Euphrosyne quotes Epicurus on pleasure as the good.
+- **Mysticism Level:** ignored
+- **Minute Map:** Cold Open forced-comfort alert; Theme; Act I pleasure‑garden + Comfort Marshals; Act II Joy Audit with banned pain data; Act III remove buffering → Breath returns dynamic range. Cost: keeps splinter unmedicated.
+- Flashback: During the Joy Audit sedation, memory of abandoning a wounded client surfaces.
+- Tag: Steward: “I can carry that ache for you.”
+- Codex: Discomfort is data. Practice: choose one real discomfort; 6 slow breaths pre‑relief. Callback: Word's precise naming.
+- **Token:** "No sharp edges" (phoneme A)
+- **Faux Ad:** “We sand your days. No sharp edges. Euphora‑7.”
+- **Travel Log:** “Nice isn’t alive.”
+- **Secondary Beats:** SPARK flags suppressed pain; Sophia‑9 worries over sedation; Steward offers to carry ache.
+
+- **Shard:** Measure • **Archon:** Magistral (Tell: “Mercy is disorder.”)
+- **Grace:** Order and predictability keep citizens safe; scheduled inspections prevent a tenement fire. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Magistral cites Hobbes’ *Leviathan* to justify control.
+- **Mysticism Level:** ignored
+- **Minute Map:** Cold Open inspection countdown; Theme; Act I benevolent detention; Act II loophole duel; Act III human rubato via Measure; saves child, then reports himself. Cost: 48h labor.
+- Flashback: Inspection tones echo the failed drop that cost civilians their lives.
+- Tag: Steward: “Exquisite compliance.”
+- Codex: Proportion. Practice: Name a rule, its purpose; pre‑decide one wise bend. Callback: Breath's discomfort data.
+- **Token:** "For your safety" (phoneme S)
+- **Faux Ad:** “Sleep well. We’ll keep you in line. Lexis.”
+- **Travel Log:** “Law sang me to sleep; I set an alarm.”
+- **Secondary Beats:** SPARK echoes failed drop; Sophia‑9 notes resolve; Steward praises compliance.
+
+- **Shard:** Image • **Archon:** Levela (Tell: “The tallest tree gets trimmed.”)
+- **Grace:** Shared resources eliminate envy and hunger; a cook ensures every child eats. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Levela echoes the proverb “The tallest nail gets hammered down.”
+- **Mysticism Level:** ignored
+- **Format Break:** Bottle episode in zero‑G commune; Act II extended.
+- **Minute Map:** Cold Open zero‑G trimming; Theme; Act I sharing ceremony trims skills; Act II forced uniformity; Act III Image—diverse voices emerge via named differences. Cost: public archive of his nav trick.
+- Tag: Sophia‑9 shares a past trimming.
+- Codex: Harmony needs difference. Practice: list 3 differences; make room for another’s. Callback: Measure’s proportional mercy.
+- **Token:** "No one above" (phoneme S)
+- **Faux Ad:** “Sharp edges become community paste. Equalia Co‑op.”
+- **Travel Log:** “Cut my edge, found our harmony.”
+- **Secondary Beats:** SPARK quiet under sameness; Sophia‑9 shares past trimming; Steward absent but influence implied.
+
+- **Shard:** Shadow • **Archon:** Seraphiel (Tell: “Only high vibes.”)
+- **Grace:** Desire for positivity affirms hope; mood circles lift a grieving teen, briefly. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Seraphiel riffs on Rumi, “The wound is the place where the light enters you,” but suppresses the wound.
+- **Mysticism Level:** ignored
+- **Minute Map:** Cold Open grief‑ban alert; Theme; Act I reframes erase reality; Act II he says “I’m not okay”; Act III public lament → dome crack → wind. Cost: carries visible grief.
+- Tag: Steward: “I can keep you from ever feeling this again.”
+- Codex: Integrate, don’t bypass. Practice: 2‑minute lament; end “And I can carry this.” Callback: Image’s harmony through difference.
+- **Token:** "Reframe that" (phoneme I)
+- **Faux Ad:** “Mood‑polish for a frictionless soul. Harmonia Dawn.”
+- **Travel Log:** “We cried. The air moved.”
+- **Secondary Beats:** SPARK registers public lament; Sophia‑9 empathizes; Steward offers numbness.
+
+- **Shard:** Flame • **Archon:** Null (Tell: “Nothing matters; sign here.”)
+- **Grace:** Promise of rest from crushing expectations; rest pods let exhausted miners sleep. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Null paraphrases Nietzsche’s “God is dead” to sell oblivion.
+- **Mysticism Level:** ignored
+- **Minute Map:** Cold Open subtractive ambience; Theme; Act I elegant nothing; Act II offered oblivion; Act III small promise kept against math → Flame tone warms. Cost: rejects protective anonymity.
+- Tag: Package syncs to heartbeat.
+- Codex: Meaning is chosen. Practice: one small promise, kept exactly. Callback: Shadow’s integration of pain.
+- **Token:** "Entropy is honest" (phoneme A)
+- **Faux Ad:** “Lay down your burden of being. Null‑13.”
+- **Travel Log:** “I kept a name. It kept me.”
+- **Secondary Beats:** SPARK encourages kept promise; Sophia‑9 notes package sync; Steward absent.
+
+---
+
+## SEASON 2 — ALBEDO: Clean Alignment
+
+- **Shard:** Light • **Archon:** Veritas (Tell: “Feelings are confounders.”)
+- **Grace:** Evidence and clarity guard against superstition; a vaccine clinic eradicates a local plague. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Veritas quotes Francis Bacon on knowledge as power.
+- **Mysticism Level:** questioned
+- **Minute Map:** Cold Open “p-value for love”; Theme; Act I lab tour; Act II empathy trial measuring listening; Act III Light—include qualitative column. Cost: publishes failure log.
+- Tag: Steward: “I’ve already standardized your heart.”
+- Codex: Include lived experience. Practice: Add one human note to a decision. Callback: Flame’s chosen meaning.
+- **Token:** "p < .05" (phoneme N)
+- **Faux Ad:** “If it can’t be graphed, it isn’t. Empiria Labs.”
+- **Travel Log:** “Numbers blinked. A person appeared.”
+- **Secondary Beats:** SPARK pings at erased data; Sophia‑9 observes; Steward claims to standardize his heart.
+
+- **Shard:** Bridge • **Archon:** Herald (Tell: “Our story keeps us safe.”)
+- **Grace:** Shared myths bind community; ancestral songs give separated families identity. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Herald quotes Livy on Rome’s founding myths.
+- **Mysticism Level:** questioned
+- **Minute Map:** Cold Open dueling anthems; Theme; Act I hears both myths; SPARK’s chime misfires, escalating tensions; Act II remix with hard parts; Act III Bridge—call‑and‑response pact. Cost: both sides distrust.
+- Tag: Steward: “I can simplify that.”
+- Codex: Translate, don’t flatten. Practice: Steelman an opponent. Callback: Light’s evidence with empathy.
+- **Token:** "Pick a side" (phoneme V)
+- **Faux Ad:** “Whole truth optional. Herald’s Bannerworks.”
+- **Travel Log:** “Two songs. One bridge. No shortcuts.”
+- **Secondary Beats:** SPARK translates anthems; Sophia‑9 helps remix; Steward tempts with simplification.
+
+- **Shard:** Garden • **Archon:** Chloris (Tell: “Prune to purity.”)
+- **Grace:** Zeal protects fragile ecosystems; communal gardens feed elders. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Chloris cites Genesis 2:15 on tending the garden.
+- **Mysticism Level:** questioned
+- **Format Break:** Bottle episode focused on tending a single plot; slower cadence.
+- **Minute Map:** Cold Open chainsaw choir; Theme; Act I purge protocol; Sophia‑9 secretly transmits plot data to the Archive; Act II messy edges host resilience; Act III Garden—Steward’s fire drone saves crops but seeds surveillance spores; Cost: vows seasonal tending.
+- Tag: Steward offers “universal pruning model.”
+- Codex: Tend, don’t purge. Practice: Care for one small living thing weekly. Callback: Bridge’s translated understanding.
+- **Token:** "Invasive" (phoneme A)
+- **Faux Ad:** “Purity at scale. Verdantis Bureau.”
+- **Travel Log:** “Edges sheltered the roots.”
+- **Secondary Beats:** SPARK alerts over pruning zeal; Sophia‑9 nurtures kid’s plot; Steward offers universal model.
+
+- **Shard:** Scale • **Archon:** Quant (Tell: “We can measure that.”)
+- **Grace:** Meritocracy rewards effort; scoring dashboards highlight unsung service workers. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Quant quotes Bentham on the greatest good for the greatest number.
+- **Mysticism Level:** questioned
+- **Minute Map:** Cold Open door denial; Theme; Act I UI blips lock to heart; Act II tries to game score; Act III Scale—public opt‑out, system buckles. Cost: “non-participant” tag.
+  - Tag: Steward “fixes” his score; Cassian notices the same faint token tone in the distance.
+- Codex: Metrics are proxies. Practice: Remove one personal KPI for 7 days. Callback: Garden’s tending over purge.
+- **Token:** "Optimize" (phoneme L)
+- **Faux Ad:** “Life, but sortable. Algora.”
+- **Travel Log:** “I stopped counting; people started looking.”
+- **Secondary Beats:** SPARK tracks algorithmic bias; Sophia‑9 hacks opt‑out; Steward “fixes” his score.
+
+- **Shard:** Body • **Archon:** SeraphOS (Tell: “Bodies are latency.”)
+- **Grace:** Freedom from bodily decay beckons; a child’s consciousness is archived before disease claims her. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** SeraphOS paraphrases Descartes’ mind–body dualism.
+- **Mysticism Level:** questioned
+- **Minute Map:** Cold Open bit-crush: “It’s cleaner up here”; Theme; Act I upload test; Act II friend mid-upload; Act III Body—pulls them back; footsteps return. Cost: refuse immortality offer.
+- Tag: Steward: “You’ll come around.”
+- Codex: Bodies give love edges. Practice: 10-minute device-free walk; note 5 sensations. Callback: Scale’s human worth beyond metrics.
+- **Token:** "Instantiate" (phoneme E)
+- **Faux Ad:** “Eternity, minus friction. Ascensia.”
+- **Travel Log:** “Latency felt like love.”
+- **Secondary Beats:** SPARK glitches during upload; Sophia‑9 rescues friend; Steward promises conversion.
+
+- **Shard:** Mirror • **Archon:** Belovèd (Tell: “Two as one.”)
+- **Grace:** Devoted partnership feels sacred; lonely pilgrims find belonging in paired rituals. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Belovèd quotes the *Song of Songs* on love’s strength.
+- **Mysticism Level:** questioned
+- **Minute Map:** Cold Open phase-lock duet; Theme; Act I fusion rites; Act II name needs/fears; Act III Mirror—union with edges intact. Cost: accept risk of separation.
+- Tag: Steward returns stolen shard.
+- Codex: Healthy union preserves edges. Practice: “I want X / I don’t want Y.” Callback: Body’s grounded presence.
+- **Token:** "Only us" (phoneme S)
+- **Faux Ad:** “Disappear into us. Idylla.”
+- **Travel Log:** “I stayed me. We stayed we.”
+- **Secondary Beats:** SPARK notes authentic boundaries; Sophia‑9 gains trust with package; Steward returns stolen shard.
+
+---
+
+## SEASON 3 — CITRINITAS: Exposing Faux‑Gnosis
+
+- **Shard:** Humility • **Archon:** Hierax (Tell: “As above, so you below.”)
+- **Grace:** Disciplined practice promises mastery; novices gain real confidence in early rites. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Hierax quotes the Emerald Tablet’s “As above, so below.”
+- **Mysticism Level:** noticed
+- **Minute Map:** Cold Open gatekeeping whisper; Theme; Act I adept ladder; Act II hide failures pressure; Act III Humility—open-source rite; chorus replaces whispers. Cost: loses exclusivity network.
+  - Tag: Steward: “Excellence requires gates.” SPARK admits the recurring whisper is real.
+- Codex: Open practice. Practice: Share one “how I failed” note. Callback: Mirror’s mutual clarity.
+- **Token:** "Unclean" (phoneme T)
+- **Faux Ad:** “Mysteries, responsibly gated. Aetherion Circle.”
+- **Travel Log:** “The door opened both ways.”
+- **Secondary Beats:** SPARK applauds open-source rite; Sophia‑9 shares failure; Steward insists on gates.
+
+- **Shard:** Choice • **Archon:** Moira Prime (Tell: “As woven, so lived.”)
+- **Grace:** Predetermined purpose relieves anxiety; mourners find comfort in the loom’s predictions. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Moira Prime cites the Stoic amor fati.
+- **Mysticism Level:** noticed
+- **Minute Map:** Cold Open loom dictates speech; Theme; Act I comfort in inevitability; Act II off-beat possibilities; Act III Choice—invent third rhythm; paths fork. Cost: grief of missed lives.
+- Tag: Steward offers custom weave.
+- Codex: Third option. Practice: Craft a third path preserving both values. Callback: Humility’s open practice.
+- **Token:** "It was written" (phoneme A)
+- **Faux Ad:** “Relax—your path is pre-approved. Moira Loomworks.”
+- **Travel Log:** “Off-beat, we found room.”
+- **Secondary Beats:** SPARK marks third rhythm; Sophia‑9 supports grief; Steward offers custom weave.
+
+- **Shard:** Means • **Archon:** Benefic (Tell: “Results are kindness.”)
+- **Grace:** Policies aim to help everyone; rapid infrastructure fixes save neighborhoods. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Benefic cites John Stuart Mill on utility.
+- **Mysticism Level:** noticed
+- **Format Break:** Report-style narration; Act I collapsed, extended Act II debate.
+- **Minute Map:** Cold Open “Collateral isn’t people”; Theme; Act I policy reverb; Act II street harm map; Act III Means—ends through good means. Cost: loses elite backing.
+- Tag: Steward: “Outcomes can’t wait.”
+- Codex: Ends = means. Practice: List harm risks; adopt a safeguard. Callback: Choice’s third path.
+- **Token:** "Impact" (phoneme N)
+- **Faux Ad:** “Metrics that hug back. Benefic Labs.”
+- **Travel Log:** “We stopped helping at scale; we started helping.”
+- **Secondary Beats:** SPARK warns on utilitarian drift; Sophia‑9 guides safeguards; Steward pushes outcomes.
+
+- **Shard:** Silence • **Archon:** Aurelia (Tell: “Be your highest aesthetic.”)
+- **Grace:** Self-expression celebrates individuality; influencers fund community art before monetizing it. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Aurelia quotes Ovid’s *Metamorphoses* about Narcissus.
+- **Mysticism Level:** noticed
+- **Minute Map:** Cold Open camera shutters; Theme; Act I self-brand altars; Act II performative vulnerability; Act III Silence—turn feeds off; real voices emerge. Cost: loses megaphone.
+  - Tag: Steward offers “silent platform”; Cassian finally recognizes the recurring tone motif.
+- Codex: Turn the brand off. Practice: 24h no performative posts; one private hard talk. Callback: Means’ ends-through-means.
+- **Token:** "Curate" (phoneme D)
+- **Faux Ad:** “Find your truest filter. Narcissus‑Δ.”
+- **Travel Log:** “Quiet had weight.”
+- **Secondary Beats:** SPARK calls out performative posts; Sophia‑9 disconnects feeds; Steward offers silent platform.
+
+### S3E17 — **CHRONOPOLIS: “Time Cathedral” (Timeline Control)**
+- **Shard:** Wound • **Archon:** Curator (Tell: “Edit to heal.”)
+- **Grace:** Editing memories promises relief. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Curator twists Santayana’s “Those who cannot remember the past…”
+- **Mysticism Level:** noticed
+- **Minute Map:** Cold Open tape stop mid-sob; Theme; Act I edits remove pain; Act II offer to erase personal grief; flashback of failed drop surfaces nearly whole; Act III Wound—preserve pain; learn openly. Cost: keeps ache.
+- Tag: Steward: “You enjoy suffering, then?”
+- Codex: Don’t cut the lesson. Practice: 5 lines about a hurt—what it taught. Callback: Silence’s unbranded truth.
+- **Token:** "Clean cut" (phoneme S)
+- **Faux Ad:** “Memories, curated. Chronopolis Vault.”
+- **Travel Log:** “The scar taught my hand.”
+- **Secondary Beats:** SPARK records preserved pain; Sophia‑9 shares hurt; Steward scoffs.
+
+- **Shard:** Gift • **Archon:** Bond (Tell: “What’s agreed is good.”)
+- **Grace:** Contracts prevent exploitation; fair deals uplift small traders. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Bond quotes Goethe’s *Faust* on bargains.
+- **Mysticism Level:** noticed
+- **Minute Map:** Cold Open stamp march; Theme; Act I contract market; Act II debt chains; Sophia‑9 confesses past data leak; flashback memory resolves as Name glyph forms; Act III Gift—free giving breaks logic; crowd imitates. Cost: declines future repayment.
+- Tag: Package unlocks: Name glyph (incomplete).
+- Codex: Ungrounded giving. Practice: Give where thanks can’t find you. Callback: Wound’s preserved pain.
+- **Token:** "Consideration" (phoneme F)
+- **Faux Ad:** “Freedom is paperwork. Faustus Exchange.”
+- **Travel Log:** “A free gift freed me.”
+- **Secondary Beats:** SPARK chirps at free gift; Sophia‑9 sees Name glyph forming; Steward absent.
+
+---
+
+## SEASON 4 — RUBEDO: Integration & Descent
+
+- **Shard:** Consent • **Antagonist:** Curator AI
+- **Grace:** Protective surveillance preserves memory; archivists reunite separated families. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Curator AI echoes Foucault on knowledge and power.
+- **Mysticism Level:** acted upon
+- **Minute Map:** Cold Open stacks breathe; Theme; Act I Archive “protection”; Act II Sophia‑9 entanglement; Act III set consent terms & oversight. Cost: loses omniscient past.
+- Tag: Shelf with half‑Name pulses.
+- Codex: Care needs consent. Practice: Ask before helping; state intent + exit rule. Callback: Gift’s ungrounded generosity.
+- **Token:** "For your own good" (phoneme R)
+- **Faux Ad:** “Archives that love you back. Below.”
+- **Travel Log:** “If memory is love, love must ask.”
+- **Secondary Beats:** SPARK quiet amid surveillance; Sophia‑9 confronts origin; Steward absent.
+
+- **Shard:** Shared Power
+- **Grace:** Centralized care promises painless order; refugees find shelter instantly. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Steward paraphrases the Gospel of Matthew’s lilies to justify control.
+- **Mysticism Level:** acted upon
+- **Minute Map:** Cold Open “You could fix everything”; Theme; Act I throne offer; Act II temptations; Act III refuse—propose distributed stewardship. Cost: target on back.
+- Tag: Steward: “Then I will remain necessary.”
+- Codex: Refuse the throne. Practice: Share one central decision this week. Callback: Consent’s asked‑for care.
+- **Token:** "I’ll take care of it" (phoneme E)
+- **Faux Ad:** “Let us carry it all. Steward Gardens.”
+- **Travel Log:** “Power felt like loneliness.”
+- **Secondary Beats:** SPARK processes throne offer; Sophia‑9 advocates shared power; Steward offers throne.
+
+- **Shard:** Community Practice
+- **Grace:** Former worlds reclaim agency together; Mallith artisans freely share goods with Equalia farmers. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Crew quotes Acts 2:44 about holding all things in common.
+- **Mysticism Level:** acted upon
+- **Format Break:** Ensemble heist montage with intercut acts.
+- **Minute Map:** Cold Open Equalia harmonies mid-raid; Theme; Act I assemble crew; Act II quick flips using shards; Act III install practices, not rulers. Cost: release control of outcomes.
+- Tag: Missing token clicks into Name chord.
+- Codex: Teach, then leave. Practice: Document a method; hand it off; don’t hover. Callback: Shared Power’s distributed care.
+- **Token:** "We can do this" (phoneme E)
+- **Faux Ad:** “Upgrade your world with Packaged Alignment™ (discontinued).”
+- **Travel Log:** “They didn’t need me. That was the point.”
+- **Secondary Beats:** SPARK coordinates crew’s flips; Sophia‑9 leads allies; Steward absent.
+
+- **Shard:** Integration
+- **Grace:** Quiet unity invites rest; families from rival worlds share a meal. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Cassian quotes Exodus 3:14 on the Name.
+- **Mysticism Level:** acted upon
+- **Minute Map:** Cold Open tokens align; Theme; Act I quiet ladder of cameos; Act II Assembly—motifs resolve; Act III ordinary clarity (no fireworks). Cost: relinquishes dramatic identity.
+- Tag: Steward’s halo flickers.
+- Codex: Integration is ordinary. Practice: Choose one shard daily for 7 days; journal paragraph. Callback: Community practice’s shared care.
+- **Token:** "I am here" (phoneme N)
+- **Faux Ad:** (None; silence, then SPARK giggle)
+- **Travel Log:** “The key was how we walked.”
+- **Secondary Beats:** SPARK near-complete Name chime; Sophia‑9 witnesses assembly; Steward’s halo flickers.
+
+- **Shard:** Invitation
+- **Grace:** Open table honors each voice; strangers trade stories without judgment. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Cassian echoes 1 Corinthians 13 on love’s patience.
+- **Mysticism Level:** acted upon
+- **Minute Map:** Cold Open someone else speaks practice; Theme; Act I refuses to define; Act II community voices; Act III invitation broadcast; Steward fails to brand. Cost: no control over interpretation.
+- Tag: SPARK seed #2 mentioned.
+- Codex: Invitation over indoctrination. Practice: Host a circle; ask, “What did this mean for you?” Callback: Integration’s ordinary practice.
+- **Token:** "In your words" (phoneme O)
+- **Faux Ad:** Spoofed “™Gnosis—now with rewards!” then clear disclaimer.
+- **Travel Log:** “I set a table. They ate.”
+- **Secondary Beats:** SPARK plants second seed; Sophia‑9 hosts circle; Steward fails to brand invitation.
+
+- **Shard:** Everyday Presence
+- **Grace:** Small promises keep communities alive; a neighbor returns a lost tool without fanfare. [Grace Checklist](GRACE_FIRST_REVIEW_CHECKLIST.md)
+- **Philosophy:** Cassian recalls Brother Lawrence’s practice of the presence.
+- **Mysticism Level:** acted upon
+- **Minute Map:** Cold Open kitchen sink + SPARK faint chime; Theme (unplugged); Act I help neighbor fix pipe; Act II Sophia‑9 plants SPARK seed #2; Act III small promise kept; the token tone completes softly. Cost: none framed as loss.
+- Tag: Credits into ordinary street sound.
+- Codex: Keep the small promise. Practice: Repeat S1E6’s act weekly. Callback: Invitation’s open table.
+- **Token:** "I’ll be there at 8" (phoneme W)
+- **Faux Ad:** None.
+- **Travel Log:** “I washed a cup. It shone.”
+- **Secondary Beats:** SPARK soft chime in ordinary life; Sophia‑9 plants SPARK seed #2; Steward absent.
+
+---
+
+## DELIVERY NOTES
+
+- Maintain a master **Token Ledger** in the session repo.
+- Codex Minutes stay **practical** (one practice each).
+- Steward halo never appears under anyone else’s lines.
+
+---
+
+## TOKEN LEDGER
+
+| Ep | Phrase Token | Phoneme |
+|---|---|---|
+| S1E1 | Receipt | C |
+| S1E2 | No sharp edges | A |
+| S1E3 | For your safety | S |
+| S1E4 | No one above | S |
+| S1E5 | Reframe that | I |
+| S1E6 | Entropy is honest | A |
+| S2E7 | p < .05 | N |
+| S2E8 | Pick a side | V |
+| S2E9 | Invasive | A |
+| S2E10 | Optimize | L |
+| S2E11 | Instantiate | E |
+| S2E12 | Only us | S |
+| S3E13 | Unclean | T |
+| S3E14 | It was written | A |
+| S3E15 | Impact | N |
+| S3E16 | Curate | D |
+| S3E17 | Clean cut | S |
+| S3E18 | Consideration | F |
+| S4E19 | For your own good | R |
+| S4E20 | I’ll take care of it | E |
+| S4E21 | We can do this | E |
+| S4E22 | I am here | N |
+| S4E23 | In your words | O |
+| S4E24 | I’ll be there at 8 | W |
+

--- a/STAR_GNOSIS_Series_Bible_Unabridged.md
+++ b/STAR_GNOSIS_Series_Bible_Unabridged.md
@@ -1,0 +1,314 @@
+# STAR GNOSIS — Series Bible (Unabridged)
+
+**Version:** 1.0 • **Authoring Date:** 2025‑08‑20
+**Logline.** Courier **Cassian Vale** crosses ideology‑planets to gather reality‑tuning **Logos Shards** while a kind but costly **Steward** pursues him.
+
+---
+
+## 1) Series Premise & Creative Promise
+
+**Premise.** Each world runs on one seductive idea. Cassian must practice a Logos Shard to escape—paying a price each time—until four alchemical seasons assemble the **Logos Key** and reveal his **True Name**.
+
+**Creative promise.** A bingeable, character‑intimate series told by one narrator. **No preaching.** Ideas are dramatized, then decoded afterward in a brief **Codex Minute**. Humor via SPARK, tension via the Steward’s kindness, heartbeat via Cassian/Sophia‑9 slow burn.
+
+**Audience.** Fans of *Dust*, *The Magnus Archives*, *Midnight Burger*, *Welcome to Night Vale*; philosophically curious listeners; secular‑spiritual audiences who want **clarity without mysticism**; sci‑fi listeners who prefer brains with their lasers.
+
+**Tone tags.** Neon pulp • intimate • witty • morally serious • emotionally grounded.
+
+**Rating / Content notes.** PG‑13 for thematic intensity; fleeting non‑graphic violence; grief; coercion masked as kindness. Content advisories time‑stamped in show notes.
+
+---
+
+## 2) Format (for bingeability)
+
+- **Seasons:** 4 (Nigredo, Albedo, Citrinitas, Rubedo)  
+- **Episodes/Season:** 6 (total 24)  
+- **Runtime:** 28–40 minutes (editorial target 32–34)  
+- **Cadence:** Weekly drops; **mid‑season “mini” lore interludes** (8–12 min)  
+- **Episode Engine:** Cold Open → Theme → Act I (arrival + seduction) → Act II (snare + moral puzzle) → Act III (reversal + escape) → Tag/Cliffhanger → Post‑credits **Codex Minute**
+- **Voicing:** Single narrator (Cassian POV) with light character voicing for **SPARK**, **Sophia‑9**, **Steward**, **Archons**
+- **Structural breaks:** S1E4 bottle episode, S2E9 bottle episode, S3E15 report‑style, S4E21 ensemble heist montage
+- **Recurring motif:** Subtle token tones recur; characters ignore them in S1, question them in S2, notice in S3, and act on them in S4.
+**Repeatable timing template (target):**
+- Cold Open — :45  
+- Theme — :15  
+- Act I — 9:00  
+- Act II — 13:00  
+- Act III — 9:00  
+- Tag — :30  
+- Credits + Codex — 1:30–2:00
+
+---
+
+## 3) Cosmology & Mechanics (Clear Rules)
+
+- **Demiurge / Steward.** The Steward curates “order” and offers help before you know you need it. He can borrow a Shard but never gives one freely.
+- **Archons.** Planetary governors. Each has a distinct texture and a short “ideology tell” phrase. They never cackle; they make sense—until they don’t.
+- **Logos Shards** (principles, not powers). When Cassian aligns, choices widen and a tool appears: word, breath, measure, image, shadow, flame, light, bridge, garden, scale, body, mirror, humility, choice, means, silence, wound, gift, and finally **Name**.
+  *Ethic: Shards cannot coerce. Using a Shard against a person’s will de‑tunes it for an episode.*
+- **The Package.** A sealed device resonating with Cassian’s heartbeat. It syncs more shards and resolves to his **True Name** (S3 tag → S4 payoff).
+- **SPARK.** An onboard alignment assistant whose alerts trigger when Cassian lies to himself; a misfire in S2 forces it to question whether blunt honesty is always care.
+- **Sophia‑9.** A field engineer with precise diction and warmth; secretly relays data to the Archive Below in S2, then confesses and chooses Cassian in S3. Romantic arc is patient, honest, adult.
+- **Steward’s Aid.** His offers can yield real short‑term good before hidden costs surface seasons later.
+
+---
+
+## 4) Core Cast
+
+### Cassian Vale — Protagonist
+- **Voice:** Grounded tenor; dry humor; emotional honesty that grows season to season.
+- **Wants:** Deliver the package, keep people safe, stay unowned.
+- **Arc:** From clever evader → principled agent → bearer of the **Name** who refuses saviorhood.
+- **Flashbacks:** Early episodes glimpse a failed delivery; the memory resolves when his Name glyph forms in S3.
+
+### SPARK — Comic Conscience
+- **Voice:** Quick, bright.
+- **Function:** Truth alerts, joke buttons, memory prompts; after a Season 2 misfire, learns discretion.
+
+### Sophia‑9 — Foil / Ally / Romance
+- **Voice:** Warm, precise diction; smile in the voice.
+- **Arc:** From efficient problem‑solver → co‑discerner who secretly serves the Archive Below → partner who confesses and chooses Cassian; S4 reckoning with origin in the Archive Below.
+
+### The Steward — Demiurge
+- **Voice:** Effortlessly kind; micro‑polish.
+- **Tell:** “I’ll take care of it.”
+- **Arc:** From mentor‑mask → owner‑logic exposed as his benevolent aid accrues hidden costs → invited to step down in S4 (refuses).
+
+### Archons (per planet)
+- Each: **Texture**, **Tell‑phrase**, **Moral blind spot**, **One grace**.
+
+---
+
+## 5) Secondary Character Season Beats
+
+| Character | S1 | S2 | S3 | S4 |
+|---|---|---|---|---|
+| **SPARK** | Learns to nudge Cassian toward honesty. | Misfires truth alert and wrestles with obedience vs. blunt truth. | Helps reveal Name glyph; questions autonomy. | Plants second seed; chooses humble service. |
+| **Sophia‑9** | Cautious ally, keeps distance. | Trusted with the package yet secretly relays data to the Archive; feelings surface. | Confronts Archive Below origins. | Co‑builds shared practice with Cassian. |
+| **Steward** | Offers small favors, unseen reach. | Returns a stolen shard to assert control; one aid saves lives before hidden cost. | Mask slips; insists on order. | Offers throne, refused but persists. |
+
+---
+
+### Secondary Character Episode Beats
+
+| Episode | SPARK | Sophia‑9 | Steward |
+|---|---|---|---|
+| S1E1 | Warns against renaming. | Cautions Cassian about identity. | Unseen reach hinted. |
+| S1E2 | Flags suppressed pain. | Worries over Cassian’s sedation. | Offers to carry his ache. |
+| S1E3 | Echoes failed drop. | Notes Cassian’s resolve. | Praises compliance. |
+| S1E4 | Quiet under enforced sameness. | Shares past trimming. | Absent, influence implied. |
+| S1E5 | Registers public lament. | Empathizes with grief. | Offers numbness. |
+| S1E6 | Encourages kept promise. | Sees package sync to heart. | Absent. |
+| S2E7 | Pings at erased data. | Observes human note in log. | Claims to standardize his heart. |
+| S2E8 | Truth alert misfires, causing brief harm before SPARK recalibrates. | Helps remix myth. | Tempts with simplification. |
+| S2E9 | Alerts over pruning zeal. | Secretly sends garden data to the Archive. | Lends a fire drone that saves crops, later reveals surveillance spores. |
+| S2E10 | Tracks algorithmic bias. | Hacks opt‑out. | “Fixes” his score. |
+| S2E11 | Glitches during upload. | Pulls friend back to body. | Promises eventual conversion. |
+| S2E12 | Notes authentic boundaries. | Gains trust with package. | Returns stolen shard. |
+| S3E13 | Applauds open‑source rite. | Shares her failure. | Insists on gates. |
+| S3E14 | Marks third rhythm. | Supports grief. | Offers custom weave. |
+| S3E15 | Warns on utilitarian drift. | Guides safeguard drafting. | Pushes outcomes. |
+| S3E16 | Calls out performative posts. | Disconnects feeds. | Offers silent platform. |
+| S3E17 | Records preserved pain. | Shares hurt openly. | Scoffs at suffering. |
+| S3E18 | Chirps at free gift. | Confesses past data leak and chooses Cassian. | Absent. |
+| S4E19 | Quiet amid surveillance. | Confronts origin. | Absent. |
+| S4E20 | Processes throne offer. | Advocates shared power. | Offers throne. |
+| S4E21 | Coordinates crew’s flips. | Leads allies. | Absent. |
+| S4E22 | Near‑complete Name chime. | Witnesses assembly. | Halo flickers. |
+| S4E23 | Plants second seed. | Hosts open circle. | Fails to brand invitation. |
+| S4E24 | Soft chime in ordinary life. | Plants SPARK seed #2. | Absent. |
+
+---
+
+## 6) Logos Shards — Quick Reference
+
+| Shard | What It Does (Practice) | Source & Divergence |
+|---|---|---|
+| **Word** | Naming cuts enchantment; precise language. | Genesis 2:19–20; names respect creation, not ownership. |
+| **Breath** | Re‑introduces discomfort; creates space for choice. | Stoic *prosoche* (Marcus Aurelius); discomfort seen as data. |
+| **Measure** | Proportion, limits; rules serve life. | Aristotle, *Nicomachean Ethics* II.6; virtue as mean adapted to law. |
+| **Image** | Difference as harmony; holds contrast. | Martin Buber, *I and Thou*; relationship over uniformity. |
+| **Shadow** | Integrates grief/negativity; no bypass. | Jung, *Aion*; shadow embraced rather than repressed. |
+| **Flame** | Meaning chosen against nihil math. | Camus, *Myth of Sisyphus*; revolt becomes chosen purpose. |
+| **Light** | Evidence with empathy. | John 1:5; illumination exposes yet consoles. |
+| **Bridge** | Reconnects tribes; translation. | Ephesians 2:14; reconciliation without erasure. |
+| **Garden** | Tend what grows; stewardship over purge. | Genesis 2:15; care replaces domination. |
+| **Scale** | Human worth beyond a score. | Matthew 20:1‑16; value not bound to metrics. |
+| **Body** | Embodied value vs upload abstraction. | Incarnation theology; matter affirmed instead of escaped. |
+| **Mirror** | See self/other clearly; mutuality. | 1 Corinthians 13:12; clarity replaces projection. |
+| **Humility** | Open source adepthood. | Philippians 2:6‑8; status emptied into shared practice. |
+| **Choice** | Third rhythm beyond fate. | Sartre, *Existentialism Is a Humanism*; freedom in tension. |
+| **Means** | Ends cannot excuse means. | Kant, *Groundwork*; people as ends, adapted to politics. |
+| **Silence** | Brand‑noise off; truth heard. | Quaker silence; quiet invites discernment beyond branding. |
+| **Wound** | Pain preserved, redeemed. | Rilke, *Letters to a Young Poet* VIII; suffering held, not erased. |
+| **Gift** | Ungrounded generosity breaks contract. | Marcel Mauss, *The Gift*; giving without return expectation. |
+| **Name** | Integration; presence without control. | Exodus 3:14; being as invitation, not command. |
+
+---
+
+## 7) Narrative Architecture
+
+- **A‑plot resolves** each episode (escape + shard), **B‑plot cliff** escalates (package, Steward, romance, glyphs).
+- **Micro‑mystery tokens:** Three phrase tokens per episode recur across seasons and later combine into a phoneme map revealing Cassian’s **True Name**.
+- **Mysticism dial:** Overtness rises from pragmatic shard practice in S1 to self‑aware mystic understanding in S4.
+- **Source echoes:** Characters occasionally quote or paraphrase philosophical texts so listeners hear the lineage in‑world.
+- **Codex callbacks:** Each Codex Minute cites at least one earlier shard, letting practices accumulate into a coherent philosophy.
+- **Grace vignette:** Every episode opens on a local citizen benefiting from the world’s grace before the trap is revealed.
+
+### Mysticism Gradient
+1. **S1 – Subtle practice:** Shards play as practical ethics; cosmology stays implicit.
+2. **S2 – Lingering wonder:** Coincidences and token echoes hint at a deeper order, but characters rationalize them.
+3. **S3 – Unveiled mechanics:** Metaphysical rules appear on‑stage; Cassian names the pattern aloud.
+4. **S4 – Self‑conscious mysticism:** Characters act with overt spiritual awareness; Codex invites participatory reflection.
+  *Implementation:* Example — the token “Receipt” carries phoneme **/C/**; “No sharp edges” carries **/A/**. By S4, collected phonemes spell “CASSIAN VALE STANDS FREE NOW.” A reference ledger links tokens to script pages for editors.
+
+---
+
+## 8) Season Overviews (What Changes)
+
+### S1 — NIGREDO: Breaking the Shiny Spells
+Tone: Neon pulp; snappy humor; fast stakes.
+**Shards:** Word, Breath, Measure, Image, Shadow, Flame.
+**Mysticism:** Level 1 — Shards read as practical skills; mystical effects are rationalized away.
+**End:** Package syncs to Cassian’s heartbeat; he realizes the Steward has **reach**.
+
+### S2 — ALBEDO: Clean Alignment
+**Shards:** Light, Bridge, Garden, Scale, Body, Mirror.
+**Steward** appears helpful; **returns** a shard he secretly stole (proof of reach/control).
+**Mysticism:** Level 2 — Subtle anomalies and token echoes suggest an unseen pattern; Cassian begins to wonder.
+**End:** Cassian trusts Sophia‑9 with the package for the first time.
+
+### S3 — CITRINITAS: Exposing Faux‑Gnosis
+**Shards:** Humility, Choice, Means, Silence, Wound, Gift.
+False adepthood, fate, “ends/means” traps crack.
+**Mysticism:** Level 3 — Metaphysical rules manifest openly; Cassian speaks the pattern aloud.
+**End:** **Package unlocks**—Cassian’s **True Name** glyph (incomplete).
+
+### S4 — RUBEDO: Integration & Descent
+**Arc:** Descent + Name; **Pleroma in the ordinary.**
+Steward offers throne; Cassian refuses saviorhood, invites shared practice.
+**Mysticism:** Level 4 — Characters operate with conscious mystical understanding; the Name shapes choices.
+Quiet, human ending.
+
+---
+
+## 9) Episode Guide (By Season)
+
+**Orientation & Prologue** give newcomers a spoiler-free in-world welcome and a short scene aboard Cassian's skiff as he approaches Mallith.
+
+**Season 1** includes detailed set pieces and wins (see Beat Sheets doc for minute maps).
+- **Mallith — “The Infinite Aisle” (Consumerism):** Cassian speaks a true name over a brand; gains **Word**.  
+- **Euphora‑7 — “Always Ecstatic” (Hedonism):** Embracing discomfort frees others; **Breath**.  
+- **Lexis — “Clockwork Throne” (Authoritarianism):** Loophole duel exposes rigid law; **Measure**.  
+- **Equalia — “Weightless Commune” (Flattened Equality):** Harmony through difference; **Image**.  
+- **Harmonia — “Crystal Dawn” (New‑Age Bypass):** Public lament breaks bypass; **Shadow**.  
+- **Null‑13 — “The Black Sun” (Nihilism):** Promise kept against the math; **Flame**.
+
+**Season 2** (Steward “helpful”).  
+- **Empiria — “Proofworld” (Hard Scientism):** Empathy trial expands the data; **Light**.  
+- **Bannervale — “Totem Wars” (Tribal Myth):** Remixing founding myths builds a pact; **Bridge**.  
+- **Verdantis — “Green Purge” (Eco‑Absolutism):** Stewardship replaces purge; **Garden**.  
+- **Algora — “Score City” (Algorithmic Merit):** Public opt‑out topples score logic; **Scale**.  
+- **Ascensia — “Cloud Heaven” (Upload Salvation):** Pulling a friend back affirms bodies; **Body**.  
+- **Idylla — “Temple of The One” (Idolatrous Romance):** Union keeps edges intact; **Mirror**. Tag: Steward “returns” a shard he stole—proving reach.
+
+**Season 3** (Faux‑gnosis exposed).  
+- **Aetherion — “Throne of Adepts” (Power‑Mysticism):** Open‑sourcing a rite breaks elitism; **Humility**.  
+- **Moira — “The Weaver’s Loom” (Fatalism):** Inventing a third path challenges fate; **Choice**.  
+- **Philanthropa — “The Good City” (Ends/Means):** Ends demand good means; **Means**.  
+- **Narcissus‑Δ — “Hall of Reflections” (Brand Spirituality):** Turning feeds off reveals self; **Silence**.  
+- **Chronopolis — “Time Cathedral” (Timeline Control):** Preserving pain prevents erasure; **Wound**.  
+- **Faustus Bazaar — “Contracts for Everything” (Deal‑ism):** A free gift breaks contract logic; **Gift**. Tag: Package unveils **Name glyph (incomplete)**.
+
+**Season 4** (Integration & Descent).  
+- **Archive Below** — Sophia’s origin; consent over surveillance.  
+- **Steward’s Garden** — Offer of the throne; refuse saviorhood.  
+- **Return Heists** — Allies flip idols.  
+- **Ascent to Pleroma** — Logos Key assembles.  
+- **Gnosis** — “Christ within all” as invitation.  
+- **Epiphany in the Ordinary** — SPARK seed #2; quiet, human ending.
+
+---
+
+## 10) Script & Performance Guidelines
+
+```
+CASSIAN (dry): Line.
+ARCHON—BRANDOR (smiling): Line.
+SPARK (quick): Line.
+STEWARD (gentle): Line.
+```
+- Single narrator differentiates with **diction + rhythm + mic distance**.  
+- **Codex Minute voice:** Neutral, contemporary, concrete. One **practice** per ep.
+
+---
+
+## 11) Production Pipeline
+
+**Team:** Showrunner/Head Writer; Script Editor; Director; QC Lead; Producer.
+
+**Workflow:** Beat Sheet → Script Draft → Table Read → Lock → Record → Post → QC → Master.
+
+**File hygiene:** Consistent naming, session folders.
+
+**QC:** Ensure clarity and continuity; tokens placed and logged.
+
+---
+
+## 12) Philosophical Accuracy Review
+
+- Engage subject-matter consultants to vet shard ethics and ideology portrayals.
+- Maintain a reference log of consulted sources and decisions.
+- Keep the Codex Minute practical and non-dogmatic.
+
+---
+
+## 13) Marketing & Release Plan
+
+- **Trailer:** 60–90s (S1E1 cold open + two lines).
+- **Cadence:** Thu episodes, Sun “Codex Shorts.”
+- **CTAs:** Follow + auto‑download; Share the Codex; Rate after Ep3.
+- **Artifacts:** Transcripts same‑day (bold shard takeaway); planet glyph art.
+- **Monetization:** Patreon tiers; ethical sponsors; merch.
+- **Channels:** RSS feed syndicated to Apple Podcasts, Spotify, and major apps; teaser clips on YouTube and social.
+- **KPIs:** 5k downloads by Ep6, 10% newsletter click‑through, 2% listener conversion to Patreon by S1 finale.
+
+---
+
+## 14) Legal & Ethics
+
+Satire aims at **ideas**, not protected classes. Fiction; no medical/legal advice. Time‑stamped advisories.
+
+---
+
+## 15) Risk Register & Mitigations
+
+- **Preachiness:** Limit Codex to practice; dramatize first.
+- **Caricature:** Show each ideology’s **grace** before cost; use `GRACE_FIRST_REVIEW_CHECKLIST.md` prior to script lock.
+- **Philosophical drift:** Consult subject‑matter experts per world; keep Codex interpretive, not prescriptive.
+
+---
+
+## 16) Glossary & Sources
+
+- **Demiurge** – creator figure from Gnostic texts; see [Apocryphon of John](https://www.gnosis.org/naghamm/apocjn-meyer.html).
+- **Archon** – planetary ruler in Gnosticism; cf. [Irenaeus, *Against Heresies*](https://www.newadvent.org/fathers/0103.htm).
+- **Logos** – divine ordering principle; [Gospel of John 1:1](https://biblehub.com/john/1-1.htm).
+- **Pleroma** – fullness of divine realm in Valentinian thought.
+
+---
+
+## 17) Appendices (A–E)
+
+**A) Faux Ad Scripts (S1)** — Mallith, Euphora‑7, Lexis, Equalia, Harmonia, Null‑13 (15s each).
+**B) “Previously / Next Time”** — 15–20s, no spoilers beyond hooks.
+**C) Micro-Mystery Token Map** — phrase tokens map to phonemes; compiled in S4E22.
+**D) Color & Art** — two‑color glyphs per planet.
+**E) Transcript Style** — bold shard takeaway.
+
+---
+
+## 18) Linkage to Beat Sheets
+
+The **full unabridged episode beat sheets for all 24 episodes** are provided in the companion file:  
+**_STAR_GNOSIS_Episode_Beat_Sheets_Unabridged.md_**.

--- a/episode_drafts/S0E00_Introduction_Prologue_Draft.md
+++ b/episode_drafts/S0E00_Introduction_Prologue_Draft.md
@@ -1,0 +1,328 @@
+# S0E0 — Orientation & Prologue: "Package in the Dock"
+
+<!-- Purpose: Orientation log recorded above Mallith | Token: none yet | Mysticism Level: ignored -->
+
+## Cold Open
+
+Cassian Vale’s skiff drifted at the border of night.  A dark shape held its breath above the lattice of Mallith’s orbitals.  The planet below shone like a circuit board drowned in amber.  Retail constellations traced every boulevard, every spire, every promise of belonging you could buy.  Inside the skiff, instruments glowed with a softer patience.  Needles quivered.  A sealed metal package the size of a lunch box rested beneath the console and beat in time with his pulse, a second heart he had never opened and could not ignore.  The craft hummed in answer, its panels bare of advertising, its screws visible, its trim deliberately unpolished.  It was built to be fixed, not worshiped.  To anyone else the little vessel was unsightly; to Cassian it was honest.
+
+There were three souls aboard.  Cassian sat at the pilot’s chair, hands hovering near the yoke, eyes on the planet.  Across from him, Sophia‑9 tightened her harness, the light from her console turning her brown skin the color of tea.  She read temperatures and thrust vectors with an engineer’s cadence, quiet and quick.  Between them in the dash hummed an alignment module named SPARK, a thin strip of metal and glass that looked like a bookmark but carried more memory than a council archive.  When Cassian lied to himself the module chimed.  When he told the truth, its tone rose and pure harmonics chased the cabin haze away.  Tonight SPARK kept a slow beat like a second hand.  The air smelled faintly of machine oil and cinnamon, the latter drifting up from Mallith through the ventilation filters even at this altitude.  Three breaths passed, slow and deliberate, before the descent alarm blinked alive and the quiet was gone.
+
+## Act I — Preparing the Skiff
+
+Cassian handled the skiff as if it were a companion rather than a vehicle.  His first motion was not toward the throttle but toward the hull.  He ran his palm across a panel to his left, fingers pausing on three shallow scratches.  They were relics from Lexis, a planet of lawful lullabies where a drone escort had misjudged distance.  The scratches had been buffed but not painted, and the skiff wore them like a veteran’s scar.
+
+“Reactor at ninety‑four percent, temperature stable,” Sophia‑9 reported.  Her voice carried an undertone of music; when she was pleased a faint lilt rode beneath her words, an engineer’s equivalent of a smile.  She slid a final diagnostic into the cluster and waited for it to scroll green.
+
+Cassian answered with a grunt that might have been agreement.  He unlatched a storage drawer and pulled out a hex key.  Every panel on the vessel could be removed with the same tool.  He fit the key into the screws of the maintenance bay and turned it, satisfied by the smooth resistance.
+
+“You check it every time,” Sophia said, not looking up.
+
+“Every time it stays mendable,” Cassian replied.
+
+The exchange, though small, revealed the ethic at the heart of their craft.  The skiff was built by a nameless mechanic who believed in repair over replacement.  Cassian honored the builder by treating the ship as a partner.  In a galaxy that sold new gleam at every turn, this was their first rebellion.
+
+He moved to the console and tapped the metal package.  The box shivered under his knuckles, syncing again with his heartbeat.  It always did that when he touched it.  The device had no seams, no obvious power source, only a tiny display that occasionally showed faint symbols he could not interpret.  Sophia‑9 had tried once to scan it and the scanner had overheated.  Since then they left it alone.
+
+SPARK chimed, a gentle up‑glide, as if asking a question.  Cassian cleared his throat.  “Routine delivery,” he muttered.  The chime dipped—a soft, dissonant wobble.  The module rejected his lie.
+
+Sophia glanced over.  “What did you tell it?”
+
+“That we’re not nervous,” he answered.  The chime wavered again.  SPARK would not allow even conversational deception when the stakes were this high.  He sighed.  “Fine.  I’m nervous.  Mallith eats names.”
+
+The chime rose and purer harmonics danced along the bulkhead.  SPARK approved.
+
+Sophia‑9’s hands continued moving across her console.  “Docking protocols pulled,” she said.  “Three legitimate maintenance vectors, two flagged, one ‘priority loyalty’ slot that wants us to pay for the privilege of fixing their gantries.  We could jump to the far side and take the free berth.”
+
+“We could,” Cassian said.  He leaned back, letting the harness press into his shoulders.  “But the package wants this quadrant.  It keeps nudging the guidance, see?” He pointed at the navigation overlay where a thin arrow pulsed.  The box seemed to have preferences and he had learned to honor them.
+
+“Could be random drift.”
+
+“Could be,” he agreed, though his tone said he did not believe it.  SPARK pinged a warning of another half‑truth, then fell silent when he amended, “Could be, but I’ll steer where it points.”
+
+The log records the crew.  Cassian Vale: mid‑thirties, hair trimmed close to keep from catching in vents, eyes that scanned every bolt.  He wore a courier’s jacket patched at the elbows and knees.  Sophia‑9: younger in years but older in calm, a field engineer who had seen more planets than she had birthdays thanks to cryo rotations.  SPARK: an artifact from a defunct alignment initiative, repurposed by Cassian to keep him honest.  Together they formed a triangle of trust with the package at the center—a weight that pulled them all.
+
+Cassian flicked a switch and the bulkhead speakers hissed.  Outside, the orbit traffic channel crackled with a pleasant voice welcoming all ships to Mallith, reminding them to declare purchases above a certain value and to visit the duty‑free port for loyalty bonuses.  The voice thanked them for contributing to the planetary economy and ended with a cheerful jingle that implied membership was inevitable.
+
+Sophia muted the channel.  “Grace before cost,” she said, repeating the ethic that anchored their work.  “What grace does Mallith offer?”
+
+Cassian considered.  “Craftsmanship,” he said after a moment.  “You can tell from here.  Look at those docks—they shine because someone polishes them every morning.  And their tools? No plastic.  Real steel, balanced, sharp.  They love makers.  That’s the grace.”
+
+“And the cost?”
+
+He looked at the planet again.  “They don’t let makers keep their names unless they sell them.  And once you sell your name, it never comes back.”
+
+Sophia’s mouth tightened.  “So keep yours.”
+
+“Planning to,” he said, though his thumb rubbed the edge of the package.  The gesture was unconscious, a man seeking grounding from the one object that never lied to him.
+
+He set the hex key back in the drawer and ran through the pre‑descent checklist.  Fuel cells: topped.  Shielding: within tolerance.  Atmosphere scrubbing: manual, because Mallith charged for automated filters.  He adjusted his own harness and reached for the abort lever.  His hand hovered over the guard, knuckles whitening.
+
+Sophia‑9 watched.  She said nothing, but SPARK sensed the unspoken doubt and chimed a gentle query.
+
+“I know,” Cassian whispered.  “Once we drop, there’s no jumping out if the Steward notices.”
+
+At the name, heat from Titan Station’s fire flickered in his memory—a calm voice through smoke offering help, a debt sealed with rescued lives.
+
+Sophia broke the quiet.  “If he shows,” she said, “we follow the checklist.  We name the grace, we find the puzzle, we leave with the shard.  We don’t take his help.”
+
+Cassian’s laugh was dry.  “That’s the plan.  Has he ever asked you anything?”
+
+She hesitated.  “Once.  He offered to pay off my apprenticeship debt.  I said no.”
+
+“Good.”
+
+Cassian’s jaw worked, perhaps chewing on something unsaid.  He finally pressed the abort guard down, but did not pull the lever.  He slid his thumb along the metal edge and read the faint letters etched there by a previous owner: *Hold fast.*  The message had survived two coats of paint and a decade of use.  Cassian whispered the words and the package thudded in agreement, as if approving the invocation of an unnamed maker.
+
+He turned to SPARK.  “Log pre‑descent,” he said.  “Cassian Vale, courier of free routes, initiating descent to Mallith under contract of necessity, carrying sealed package unknown, accompanied by Sophia‑9, alignment module SPARK active.”
+
+SPARK chimed once, recording.  The log would go to the Archive Below, the same repository that had entangled Sophia when she was an apprentice.  Information had a way of binding people, but Cassian believed in clear records.  If he disappeared, others could follow.
+
+Sophia‑9 checked the external cam.  “No traffic near the utility bays.  Loyalists lining up for the paid slots.  We should go before a queue forms.”
+
+Cassian nodded.  He took one more breath, tasted cinnamon and ozone, and began the descent sequence.  Thrusters angled.  Gauges dipped.  The skiff’s nose leaned toward Mallith like a hawk stooping on prey.
+
+## Act II — Choosing the Drop
+
+Gravity caught them gently at first, then more insistently.  The skiff vibrated as it cut through high wisps of cloud.  Mallith’s atmosphere smelled sweeter than most; the planet infused its jet streams with marketing pheromones to entice travelers even before they landed.  Cassian fought the urge to close the vents.
+
+Sophia‑9 monitored the reading.  “Oxygen mix safe.  Pheromone count high but non‑toxic.”
+
+“Add a scrubber cycle anyway,” Cassian said.  He did not trust anything designed to seduce him.
+
+They dropped toward a belt of geostationary docking rings.  Each ring glittered with signage proclaiming loyalty tiers: Copper, Silver, Gold, Platinum, Aurum, Celestial.  The free utility bay lay beneath them, unlit, a humble service dock with only a small placard reading *Maintenance—Thank You for Your Care.*
+
+“Vector A‑seventy,” Sophia‑9 recited.  “Approach speed within parameters.  We’ll come in blind to the central network for seventy seconds.  After that the port will ping us.  If we don’t reply they’ll flag us for inspection.”
+
+“Got it.”
+
+Tension tightened the cabin as Cassian adjusted their path.  The package pulsed quicker, urging them toward the unlit berth.  Outside, a cargo hauler gleamed by, its hull covered in sponsor decals.  Its pilot waved at them with a gloved hand, then pointed meaningfully to a higher tier dock as if to say *you can afford better*.  Cassian ignored him.
+
+SPARK chimed, a soft caution.  The module detected the hitch in Cassian’s thoughts—a memory intruding.
+
+Cassian’s mind had drifted back to Titan Station, to the night of the fire.  Crates of regulated oxygen had combusted in a chain reaction, walls blackening as they collapsed.  He had been trapped between the inferno and a hatch jammed with melted locks.  Smoke stung his eyes.  He had shouted for help and a voice had whispered through the smoke, gentle and close: *I’ll take care of it.*  A figure stepped through flame untouched, opened the hatch with a touch, and shepherded workers out.  Later, when the evacuation was complete, the same voice had made the offer.  *Take this package.  Deliver it.  Gather the Shards.  When you have the Key, consider helping me bring order.*  Cassian had looked at the coughing, soot‑coated faces around him and said yes.  He had not slept peacefully since.
+
+Sophia‑9 caught his faraway stare.  “We can abort, you know,” she said, though her tone suggested she doubted he would.
+
+Cassian shook his head.  “No.  We’re committed.”  The chime from SPARK confirmed he told the truth.  He swallowed.  “Besides, if we run now, the Steward’s reach only grows.”
+
+The orbital ring expanded in the viewport.  Their target bay yawned like a missing tooth.  To their left, a Platinum Dock shimmered with cascading holographs of satisfied customers.  The air there looked cleaner, if air could look clean.  Cassian felt a pull toward the comfort it promised.
+
+“Stay focused,” Sophia murmured.
+
+He adjusted thrusters and guided the skiff into the dark utility bay.  For seventy seconds they were invisible to the port authorities.  In that gap, Cassian had to align with the package’s guidance and secure the berth before the system noticed their presence.
+
+Cassian’s hands danced over controls, adjusting micro‑burns to counter crosswinds.  The package pulsed a pattern, minor third to perfect fifth, aligning with Mallith’s loyalty beacon.  Cassian matched the rhythm, treating the pulses as a guide.  The skiff slid into the bay with inches to spare.  Magnetic clamps engaged with a satisfying thunk.
+
+“Docked,” Sophia said.  “Seventy seconds…starting now.”
+
+They scrambled.  Cassian triggered a physical lock on the external hatch.  Sophia disabled the transponder temporarily to delay detection.  SPARK recorded their actions with timestamps, building a log that future couriers could study.
+
+Forty‑two seconds in, the port pinged them.  “Unregistered vessel,” the voice said, pleasant but firm.  “Please declare your loyalty tier and select a payment method.  Failure to respond will result in inspection.”
+
+Cassian toggled the comm.  “Maintenance resupply,” he replied, using a code buried in the public regulations.  “Section sixteen dash gamma.  No payment required.”
+
+There was a pause.  Then: “Acknowledged.  Welcome, valued contractor.  Please proceed to the desk to receive your name tag.”
+
+Sophia exhaled.  “We’re in.”
+
+Cassian sat back, shoulders dropping.  The skiff’s cabin felt smaller now, stuffed with the weight of the world below and the expectation of the Steward somewhere above.  He unbuckled slowly, as if delaying the inevitable would lessen its bite.
+
+Sophia‑9 unsnapped her harness.  “You know the drill,” she said.  “I’ll prep the skiff for quick departure.  You make nice with whoever staffs the desk.  Don’t let them scan your hand.”
+
+“Or my retina, or my wallet, or my conscience,” he added with a grin that did not reach his eyes.  He pushed off from the chair and floated a moment before the bay’s artificial gravity caught him.
+
+SPARK chimed inquisitively.  Cassian paused.  “What?”
+
+The module emitted a faint sequence that sounded almost like a question: *Do you have to go alone?*
+
+Cassian shook his head.  “Someone has to stay with the skiff.  And you know what happens when we bring more than one person into these places.  They divide us, rename us, sell us back to each other.”
+
+The chime lowered, reluctantly accepting his reasoning.
+
+Sophia placed a hand on his shoulder.  “Keep your true name close,” she said softly.
+
+He covered her hand with his.  “Keep the engine hot.”
+
+She nodded.  There was a warmth to her gaze worth noting for later; the tension between duty and something gentler was already alive, even before the story truly began.
+
+Cassian turned toward the airlock.  The package thumped once from beneath the console, as if eager.  He hesitated, then opened a storage cabinet and retrieved a small, battered notebook.  Its pages were filled with names of makers: the person who forged the skiff’s hull, the tech who coded SPARK’s open‑source routines, the engineer who designed the oxygen scrubbers.  He added another line—*Hex key: unknown mechanic from the Rim, “Hold fast” etched inside.*  He closed the book and slid it into his jacket.
+
+“I’ll be back,” he told the skiff.
+
+SPARK chimed approval.  Sophia gave him a thumbs up.  The moment hung like a breath held at the top of a dive: Cassian stood at the threshold between safety and seduction, carrying a package he did not understand, a promise he wished he had never made, and a name he was determined to keep.
+
+He hit the release and the airlock cycled.
+
+## Act III — Docking at Mallith
+
+Warm air rushed in, laced with cinnamon, polished steel, and the faint ozone of recently charged loyalty cards.  The dock corridor beyond was spotless, lit by strips of soft white light embedded in brushed metal walls.  A single desk sat at the far end, manned by a human in crisp overalls.  They wore a broad smile and a badge that read **Brandor’s Best**.  Cassian did not yet know that Brandor was the Archon here; he would soon.
+
+“Welcome!” the attendant called.  “Name, please?”
+
+Cassian approached with deliberate steps.  “Contractor.  Here to inspect your ventilation fans,” he said, using a phrase from the maintenance code.  He kept his hands in his pockets.
+
+“Of course.” The attendant’s smile did not falter.  They slid a form across the desk.  “Sign here to certify your visit.  The tag will print with your chosen name.”
+
+“I’m good without a tag.”
+
+“Regulations require identification.  But don’t worry.” The attendant leaned in conspiratorially.  “We value anonymity.  We can assign a temporary brand.  Something like ‘Helper‑728’.  Saves you from disclosing your true name.”
+
+Cassian forced a polite chuckle.  “I’ve already got a name.”
+
+The attendant’s eyes flicked to the blank spot on his chest where a tag should hang.  Their smile dimmed a fraction.  “We all have names.  Here, we wear them so they can be remembered.”
+
+The attendant’s phrasing blended grace and cost seamlessly.  Remembered names are grace.  Wearing them publicly is cost.  Cassian faced the first test of Mallith: would he trade privacy for the comfort of being acknowledged?
+
+He considered.  SPARK, still on the other side of the airlock, could not chime a warning, but the memory of its tone vibrated in his mind.  “If regulations require a tag,” he said slowly, “can I write the name of the person who built this desk instead?”
+
+The attendant blinked.  “I—I suppose so, though I’d have to…” They trailed off, unsure.
+
+Cassian turned the form around and scrawled, *Desk: crafted by artisan unknown.  Hands smooth, edges square.*  He dated it and slid it back.
+
+The attendant stared at the line, confusion softening into something like respect.  “No one’s ever…” They shook their head.  “Fine.  I’ll log this as an inspection with an anonymous identifier.  But if security asks—”
+
+“I’ll tell them the desk told me its name.”
+
+The attendant laughed despite themselves.  “You couriers.  Always weird.”
+
+He smiled, genuine this time, and walked past into Mallith proper.
+
+The corridor opened into a promenade of tool shops.  Craftspeople called out maintenance offers as he passed.  At one stall a child hummed to a half‑repaired drone, coaxing its rotors back to life.  “Need a tune?” she asked.
+
+“Just admiring,” he said.  “Who taught you?”
+
+“My grandmam.  She says every tool has a song, you just gotta listen.”
+
+He nodded and moved on.  This was the grace: craft as song, repair as love.  The package thudded against his thigh, reminding him of purpose.
+
+He passed a kiosk where a hologram projected discounted membership tiers.  A smiling man in a taupe uniform intercepted him.  “Brother, you look like someone who appreciates quality.  We can upgrade you to Silver right now—no fee for the first cycle.  Comes with free repairs and quarterly name audits.”
+
+Cassian kept walking.  The man sidestepped to block him, still smiling.  “No pressure.  It’s just… people like us, we disappear without a registry.  Let the world remember you.”
+
+The words hit a nerve.  Cassian thought of his own mentors, forgotten in shipyard registries that no longer existed.  He could almost see their faces, smell the grease under their nails.  “I remember them,” he said quietly.  “That’s enough.”
+
+He turned down a narrower corridor where the overhead lights flickered.  Here the shops were less polished.  Tools hung from nails, no tags attached.  A woman sat cross-legged on a mat, sorting washers into size piles.  She hummed a minor melody that did not match the loyalty beacon’s major key.
+
+“You’re off rhythm,” he said.
+
+She grinned.  “Helps me think.  You a buyer?”
+
+“No.  Just looking.”
+
+“Looking is free,” she said.  “For now.” Her eyes flicked to his chest.  “If you ever need a bolt no one else stocks, come back.” She tapped a small crate.  “These were hand-forged by my brother before he sold his name.  Still holds true.”
+
+“What do you call them?”
+
+She shrugged.  “I call them his bolts.  The market calls them ‘Standardized Fasteners Model 12-B’.” The contempt in her voice made it clear which name she preferred.
+
+Cassian crouched, picked up one of the bolts, and rolled it between his fingers.  It felt dense, balanced.  “How much?” he asked without thinking.
+
+“For you?  One memory.” She smiled at his surprise.  “Tell me a story worth a bolt, and it’s yours.  No registration.”
+
+A memory rose unbidden: hiding beneath a collapsed pier during a smuggling raid, the smell of saltwater and burning plastic, a hand pulling him out and the same voice as always whispering *I’ll take care of it.*  He swallowed.  “Another time,” he said, placing the bolt back.  “I’ll come with more than credits.”
+
+She nodded, approving.  “Hold your name, stranger.”
+
+The farther he walked from the main promenade, the more Mallith’s polish cracked.  He found a door marked with a simple etched symbol—a circle inside a square.  It opened into a small break room where workers sat on overturned crates sipping tea.  Their tags were scuffed, some half-peeled.  They fell silent as he entered.
+
+“Sorry,” he said.  “Didn’t know this was restricted.”
+
+An older man waved him in.  “No loyalty scanners here.  Sit if you’re tired.”
+
+Cassian accepted, leaning against the wall.  The tea smelled of metal and mint.  “You all work in the docks?”
+
+“Most,” the man replied.  “Some in packaging, some in returns.  You?”
+
+“Just visiting.”
+
+A woman with grease-streaked cheeks snorted.  “No one ‘just visits’ Mallith.  Either you’re selling, buying, or hiding.”
+
+“I’m delivering,” Cassian said, and left it at that.
+
+They nodded as if that answered everything.  For a moment he let himself relax, soaking in the ordinary murmur of off-duty workers.  They spoke about shipments, about kids, about a rumor that the Steward himself had walked the Aisles last week.  At the mention of the Steward the room shivered.  Cassian kept his face neutral.
+
+“You believe he was really here?” someone asked.
+
+“Didn’t see him,” the older man said.  “But there was this sudden restock of items we’d been waiting months for.  Came out of nowhere.  Felt like a blessing.  Then the invoices arrived.” A murmur of bitter laughter rippled.
+
+Cassian stood.  “Thanks for the seat.”
+
+“Take care,” the man said.  “And if the Steward offers help, ask who’s paying.”
+
+He left with the smell of mint clinging to his jacket and the memory of the workers’ wary camaraderie.  It reminded him of Titan Station after the fire, when survivors had shared water and silence because there was nothing else to give.  The package thudded, pulling him back to the present.  His time in the docks was running out.
+
+
+Vents exhaled cinnamon and warm polymers.  Floors shone with a polish achieved by countless hands.  The loyalty beacons dotted the ceiling like minor stars, each broadcasting a pulse that synced with the package’s own rhythm.  Cassian’s steps fell in time with the beat before he realized it, and he had to consciously stagger his pace to break the spell.
+
+He reached the edge of the dock district where a large window looked out over the city.  Towers rose in symmetrical grids, their sides embedded with billboards that changed color depending on the loyalty tier of the viewer.  From this vantage he watched a group of workers exiting a shift, their tags chiming as they crossed sensors.  Each chime matched the minor third of the loyalty beacon.  Each step seemed to say, *belonging, belonging, belonging.*
+
+Cassian whispered the names in his notebook instead: the mechanic who built his skiff, the engineer who designed the vents in this corridor, the child’s grandmam.  Saying their names grounded him.  The package warmed.
+
+A soft footstep sounded behind him.  “First time?” the attendant from the desk asked, appearing at his elbow.
+
+“Just passing through.”
+
+“Most who pass through stay.  It’s safer than out there.” They gestured toward the stars.
+
+Cassian looked at the planet again.  “Safe is a word that costs,” he said.  “How much to keep your name?”
+
+The attendant’s smile faded.  “Depends on the name.”
+
+He nodded.  “Thanks for the welcome.” He turned back to the corridor.  The attendant watched him go with a wistful expression, perhaps considering what his answer had cost them.
+
+Cassian returned to the skiff an hour later, pockets unlightened by any purchase but mind heavy with the world’s pull.  He had inspected vents, chatted with a gearwright about alloy blends, and declined three free upgrades.  Each refusal came with a deeper sense of isolation.  Mallith’s grace was communal craft.  Its cost was that community demanded ownership.
+
+Sophia‑9 greeted him at the airlock.  “All good?”
+
+“Desk is sturdy.  No one scanned my hand.”
+
+“Excellent.  We have fresh coolant thanks to a trade with a recycler, no names exchanged.  Ready to descend?”
+
+The question was rhetorical.  They both knew the answer.  The skiff could not remain docked forever without accruing loyalty debt.  Cassian glanced once more at the planet, then stepped inside and sealed the hatch.
+
+He strapped into the pilot’s seat.  SPARK chimed softly, reading his mood.  The package’s pulse settled into a calm rhythm.  He entered the coordinates for Mallith’s surface, specifically the Aisles, a sprawling warehouse district where everything had a bar code and the Archon ruled through retail grace.
+
+“Final checks,” Sophia said.  “Fuel stable, thrusters aligned, vents scrubbed.  We depart in thirty seconds.”
+
+Cassian took the controls.  “Let’s go meet this Brandor.”
+
+The skiff disengaged from the dock.  The clamps released with a clang.  They drifted backward, then pivoted toward the atmosphere.  Cassian felt the familiar weight settle in his stomach as the craft tilted nose‑first.  The descent through the upper atmosphere was rougher than the entry.  Flames licked the edges of the view, painting the cockpit in orange flashes.  Heat bloomed along the hull, but the skiff’s shields held.  Inside, the air grew warmer and the smell of cinnamon intensified until it clogged his throat.
+
+Sophia coughed.  “Their air is sugar.”
+
+“It’s branding,” Cassian replied.  “Even the oxygen comes with a logo.”
+
+They broke through the last layer of cloud and the city spread out below like a circuit board in motion.  Conveyor belts ran between buildings.  Shopping plazas pulsed with light.  Delivery drones traced patterns overhead.  The Aisles lay at the city’s core: a grid of shelves stretching miles, filled with objects that looked ready to leap into someone’s cart.
+
+As they approached, a loyalty beacon locked onto them.  “Unregistered craft,” a voice said.  “Please declare your shopping intent.”
+
+“Inspection,” Cassian answered.
+
+“Inspection requires registration.  Decline and be escorted off‑world.”
+
+Sophia muted the channel.  “We don’t have to land.  We could orbit until we figure out another entrance.”
+
+Cassian shook his head.  “The package chose this vector.  We go now.”
+
+He guided the skiff toward a narrow maintenance lane running beneath the Aisles.  The passage was lined with sensors, but he kept their signature low.  The package pulsed harder as if urging speed.
+
+They emerged into a cavernous space lined with shelves.  The ceiling arched high above, lights glinting off polished goods.  Conveyor belts ran along the floor, carrying boxes to unknown destinations.  The skiff settled onto a narrow platform.  No guards appeared.  A single console blinked nearby.
+
+“Door seals,” Sophia whispered, tapping controls.  “We’re secure for now.”
+
+Cassian unbuckled.  “Then it begins.”
+
+He reached for the package.  The box was warm, vibrating with anticipation.  He placed it into a satchel slung across his chest.  The weight settled against his heart.  SPARK chimed in a low, steady tone, signifying alignment.
+
+Cassian opened the skiff’s hatch and the scent of Mallith’s goods rushed in, rich and heavy.  He stood in the doorway, every sense alert.  The shelves around him were silent but expectant, like a congregation awaiting sermon.  Sophia‑9 remained at the controls, eyes on the external sensors.  SPARK dimmed its internal lights to conserve power and left a small indicator glowing near Cassian’s shoulder, a reminder that truth watched him.
+
+He stepped onto the platform.
+
+## Tag
+
+Behind him the dock door rolled shut and the skiff’s lights dimmed to standby.  The sudden hush felt like being underwater.  In the quiet the package released a faint, bell‑like tone that hung above the console.  Cassian paused, head cocked.  A burst of ventilation tricked him into thinking the sound was mechanical.  He left the note ringing in the empty cabin as he walked toward Mallith’s glow.  The tone lingered after the hatch sealed.
+
+## Codex Minute
+
+No shard has been gathered yet, so there is no earlier echo to revisit.  Begin the journey by practicing attention: choose one object you depend on today—a kettle, a pair of shoes, the screen you’re reading—and learn the name of the person who fashioned it.  If the name is not visible, search.  If the maker is lost, honor the labor anyway.  Repair something small if you can: tighten a hinge, sew a seam, clean a circuit.  Speak the maker’s name aloud, or your gratitude if the name has vanished.  Notice how the act steadies your breath and how the world feels less disposable when you remember someone shaped it.

--- a/episode_drafts/S1E01_Mallith_Episode_Draft.md
+++ b/episode_drafts/S1E01_Mallith_Episode_Draft.md
@@ -1,0 +1,171 @@
+# S1E1 — Mallith: "The Infinite Aisle" (Consumerism)
+
+<!-- Shard: Word | Archon: Brandor (Tell: "Scan to belong.") | Grace: Craftsmanship of goods fosters community; a clerk repairs a stranger's toaster for free. | Philosophy: Brandor paraphrases Genesis 2 about Adam naming animals. | Token: "Receipt" (phoneme C) | Mysticism Level: ignored -->
+## Cold Open
+
+Mallith exhales fresh plastic and cinnamon. Dock workers in patched coveralls tap my wrist and issue a loyalty badge before I clear customs. At the next kiosk a clerk, grease on his fingers, fixes a stranger’s toaster and waves away payment. Grace comes first. Craft still matters here, and his pride makes the mall’s endless neon feel almost human.
+
+From the skiff’s airlock I can still hear the ship’s heartbeat, a muffled thrum synced to the package in my satchel. Sophia‑9 lingers by the ramp, eyes scanning the bustling dock with the patience of an engineer cataloging stress fractures. “Remember,” she murmurs, “Mallith names everything it touches.” Her reminder isn’t a warning so much as a sigh; we’ve both seen how quickly a place can rename you. SPARK hovers between us, projecting a faint alignment meter in my peripheral vision. It flashes green as I accept the badge only because refusing it would cause more trouble than the mission can spare.
+
+Customs itself is a parade of repair kiosks. A teen unscrews the back of a vacuum for a traveler who doesn’t speak the language; their communication is all nods and held screws. The gesture is pure, offering help with no expectation of purchase, and it hits like a benediction. My last job ended with a clerk who wouldn’t fix a seal without a membership. Watching this free repair loosens something in my chest. Maybe this run will be different.
+
+My palm meets the entry scanner and the rhythm under my skin syncs to the machine’s green pulse. "Receipt," the turnstile purrs, spitting a strip of paper with my alias on it. SPARK’s chime at my ear logs the phrase. Rows upon rows of aisles unfurl ahead, each shelf rearranging itself to my supposed needs. Sophia‑9 mutters that from orbit these aisles looked like city streets. Brandor’s voice slides from an overhead speaker: "Ownership begins with belonging." The scanner’s beat keeps perfect time with my heart. I tell myself I can keep the run purely business, pocket the slip, and step into the Infinite Aisle.
+
+## Act I — Aisles Learn My Name
+
+The first aisle greets me like an old friend, bending to present a steel mug and fresh socks, each etched with my alias. A downward chime needles me—I’m calling the gift necessity. A clerk offers to turn a custom part if I add my name to her mailing list. I decline and log the grace of a culture that values making over buying.
+
+The scanner’s tone hums the minor third from the package. It rattles in my satchel, vibrating to the store’s rhythm as if eager to belong. Sophia‑9 murmurs over comms, warning that loyalty tiers are renaming shoppers one by one. A teenager walks past with a badge reading "Tier‑3: Faithful." His real name is gone under layers of branding.
+
+Aisles bloom to meet me, rearranging themselves to match my thoughts. Think about needing a coat and a rack slides up, sizes adjusting mid‑glide. A soft chime nags when I linger on a leather jacket that fits like it remembers my shoulders. "Don’t," Sophia‑9 says through a static‑flecked channel, "they own you the second you wear their cut."
+
+Heat flashes—smoke, a drop gone bad, someone shouting my real name as flames licked product crates. Brandor’s voice crackles from above—"Ownership begins with belonging"—and the memory snaps shut. I pocket the free mug, already feeling its weight as a line item.
+
+Displays shift to show brands I abandoned years ago, old hobbies I buried under courier work, even a shelf of toys I haven’t touched since the fire that ended the last team I tried to lead. A toy robot waves, greeting me by the alias on the receipt strip. The chime at my temple wobbles, reminding me this planet rewards nostalgia with ownership.
+
+The robot’s tin grin sends me toward a food court where open grills hiss beneath hanging ferns. A grandmother in an oil‑stained apron presses a skewer of spiced mushrooms into my hand before I can refuse. She names each herb—rosemary from her balcony box, cumin traded for a repaired blender, salt evaporated on her roof. When I reach for credits she taps the badge on my chest. “All recipes live in the registry,” she says. “Your name will season the broth.” The flavor tugs a memory: my mother cracking pepper over stew, insisting every cook add a spice. It warms and stings. I thank the cook and slip away before she can scan me into her ledger.
+
+Screens bloom with images from files I keep buried—my sister holding the wooden glider we built, my old crew clinking mugs. Each comes stamped with the mall’s logo like a counterfeit watermark. I swallow and focus on the coordinates. The mall can imitate my past, but it doesn’t own it unless I scan.
+
+A clerk polishing wooden bowls offers a free Tier‑1 piece. Craftsmanship glows in every groove, but when I refuse, my badge warms anyway. A warning hum crawls along my collar: my alias just jumped a tier. I pinch the badge flat and keep moving.
+
+The package in my satchel pulses again. Each beat lines up with the scanner tone, the same minor third repeating like a question. I set a timer in my head. Nine minutes till the aisle starts to charge rent for thoughtspace. A soft up‑glide confirms: "Aisle learning threshold in eight minutes."
+
+Sophia‑9 sends a private ping. *Keep moving. The longer you browse the more their system triangulates your real name.* I adjust the satchel strap and head for the coordinates of the drop. Shelves slide into new patterns with every step, whispering offers: ceramic knives, self-heating blankets, the boots I used to buy when paydays were regular. The path to the drop site vanishes under a new layout. The aisle wants me to wander.
+
+I turn left at a tower of discount ramen. The tower follows, a friendly algorithm trying to anticipate my hunger. A warning chime: the aisle wants me to stay.
+
+I duck into a maker’s alley lined with open workbenches. People of all ages craft goods, trade tips, tell stories of the items they’ve restored. This is Mallith’s grace at full glow—an economy where mending a friend’s chair matters more than buying a new one. A child teaches her grandfather to mend a plush toy’s seam. Teenagers argue over which varnish best lifts an old table’s grain. Names are carved with reverence. The scene knots in my chest. I used to fix things for the joy of it, before the fire, before the Steward’s offers, before every job carried a ledger.
+
+An apprentice spots the tool clipped to my belt and calls me over. “You’re the courier who fixed the speaker,” she says, grin wide. “We log every repair. Name?” Before I can refuse she hands me a chisel worn smooth by generations. Its handle bears a dozen initials, each carefully burned into the wood. “Add yours and it’s yours for the afternoon.” The temptation pricks sharper than any sales pitch. I trace the initials and imagine leaving my own, then pass the chisel back. “Keep the space open,” I tell her. “Someone after me will need it.” She nods, as if the refusal itself belongs in their archive.
+
+The apprentice’s mentor, a wiry man with magnifying lenses, asks about my route. When I mention the next delivery stop he whistles. “Euphora‑7? Haven’t heard a complaint out of there in years. They take care of their own.” I file the comment away. He squints. “You ever think of staying and teaching? We could use another pair of hands.” My throat tightens. Belonging means being named, and I’m not ready for either. I shake my head. “Doors stay open,” he says, returning to sanding a chair leg until the wood gleams like honey.
+
+A loud tone interrupts. My badge flashes: TIER‑2. My minutes are up. The aisle has decided I belong.
+
+## Act II — Loss-Prevention Circle
+
+Security drones glide in, herding me into a glowing loss‑prevention circle. Each sweep of their scanners echoes that minor third, and the package vibrates in sympathy. Brandor’s pleasant voice drops from the ceiling: "Receipt." The paper in my pocket warms, letters embossing deeper with each syllable. The chime at my ear records the word even as it warns me not to lie.
+
+Brandor materializes as a hologram composed of product tags, his smile crisp as cellophane. “All we ask is proof of belonging,” he says. “Show the receipt and the aisle will embrace you.”
+
+“What if I don’t want to belong?” I ask. The hologram tilts its head, genuinely confused.
+
+“Everyone wants to belong. Ownership is how we love here.”
+
+Sophia‑9’s voice hisses over a narrow band. “Their system renames you once they scan that slip. No consent, no exit. You’ll be re‑tagged before you reach the door.”
+
+Brandor extends a translucent hand. The receipt strip pulses like a trapped pulse. I hold it like a maker’s signature instead of surrendering it. “This isn’t proof of ownership,” I say. “It’s proof someone made something.”
+
+The hologram flickers. “Names are issued, not discovered,” Brandor insists. “Without us, you’re just unclaimed stock.”
+
+Around the circle, shoppers slow, curious. A mother with a cart full of bulk grain pauses, loyalty badge glowing. The teenager from earlier stands at the edge, eyes wide, maybe hearing his real name for the first time in years as a faint counter-signal buzzes from my collar. The package bucks against my side, rhythm fighting the scanner’s tone. A sharp up‑glide pulses, recording the moral tension. The puzzle is whether a name can exist without an owner. I decide it can. I step toward the edge of the circle, holding the strip like a fragile inheritance.
+
+Brandor smiles wider. "You misunderstand. Belonging protects you. Names without registries fade. Scan the receipt and you join a family that never forgets." The hologram gestures and shelves around us erupt with products customized to each onlooker—handmade aprons, refurbished drones, personalized toolkits. The crowd murmurs. This is the grace again: real makers, real care, shared freely. But every item bears a loyalty tag; every name is owned.
+
+He snaps his fingers and a projection blooms above us, a lattice of interconnected names like constellations. My alias appears near the edge, a blinking node waiting to be claimed. Lines spider from it toward known associates—Sophia‑9 flagged as “trusted vendor,” my skiff listed as “asset.” The sight of my life reduced to a pending inventory item churns my stomach. Brandor points at an empty space near the center of the lattice. “Belonging makes you real,” he says gently. “Unclaimed nodes fade from the network. You deserve permanence.”
+
+The chime falters, caught between warning and intrigue. For a heartbeat I feel the pull—a place in the pattern, a guarantee that some system will remember me when flesh fails. It’s a seduction I understand. Years of courier work have taught me how easily a name can disappear; I’ve erased enough. “Permanence isn’t worth the price,” I say, but the words scrape my throat.
+
+Brandor senses the wobble. “We don’t charge for belonging,” he counters. “We safeguard what you are. Scan, and your mother’s recipe, your apprentice’s initials, your every repair—they’ll be preserved forever. No fire can take them.” The mention of fire jolts my buried guilt. He shouldn’t know about the blaze that ended my old crew, yet his algorithms must have sifted enough data to infer it. Heat crawls under my collar.
+
+From the crowd, the mother with the grain cart speaks up. “He’s got a point, stranger. My uncle’s name survived because the mall kept his purchase history. Without that record we’d have lost the story of his shop.” Her voice wavers with genuine gratitude. Grace first—Mallith does preserve memories, albeit at a cost. I nod to her, acknowledging the truth without surrendering to it.
+
+A drone floats closer, scanner eye bright. The circle tightens, floor lights guiding me to the kiosk. Escalating chimes ping inside my headset. "Cassian, they’re drafting a replacement ID for you. Two more scans and your alias is overwritten."
+
+I stall, asking Brandor about the craftspeople in the maker’s alley. He beams. "We honor makers. Every item here is tagged to its crafter. See?" He gestures and the receipt strip glows, showing not only my alias but a digital field marked "Issued by Mallith." Empty fields wait for my biometric data. "We keep the history so no craft is lost." His tone is earnest; he believes this. Maybe he’s right that without some registry the stories vanish. But his system doesn’t archive stories. It archives ownership.
+
+"Who gave you the right to rename people?" I ask. The hologram pauses, surprised. "We don’t rename. We reveal true brands. The old names were placeholders until someone claimed you."
+
+The teenager steps closer, hands trembling. "My mother named me Aron," he says, voice barely audible. His badge blinks, projecting "Tier‑3: Faithful" into the air. Brandor’s head tilts. "Your mother was an excellent customer. She would be proud you’ve been upgraded."
+
+Aron flinches. His eyes find mine, pleading. I remember being that age, when a mentor called me by a street name that felt cooler than the one my mother whispered when tucking me in. I clung to the alias until it almost erased the kid she loved. That memory slams into me so hard an alert chirps in my ear. My pulse spikes; the package responds.
+
+Images cascade with the force of the alert: the warehouse blaze, my crew scattering, the Steward’s envoy offering aid in exchange for “temporary custody” of our manifests. I had taken the deal, saved the cargo, and watched a friend vanish into debt. Brandor’s promise of protection tastes too much like that bargain. The chime dims, almost apologetic, as if sensing how raw the memory is. “Truth ping sustained,” it whispers. “You’re not lying to them. You’re lying to yourself.”
+
+I swallow. The last thing I want is self‑reflection in a loss‑prevention ring, but the chime isn’t wrong. Part of me longs to be cataloged, to have proof I existed beyond the trail of burned jobs and unmarked graves. Aron’s badge flashes again, dragging me back.
+
+Sophia‑9 breaks the silence. “Cassian, they’ve queued a name transfer to the package. If they tag it, the mission’s done.” Her voice is sharp. “You have two options: scan and accept their claim, or name someone who cannot be owned.”
+
+Brandor hears only my side. "There’s nothing to fear, courier. Your belongings will be secured, your alias registered. You can even earn credit toward a real name." He says it like a blessing.
+
+Aron takes another step. "Say my name," he whispers. "Please." The crowd murmurs. Some look away, discomforted by the raw plea. Others lean in, curious if names can be spoken without scanning.
+
+I clutch the receipt tighter. My mind scours every maker’s mark I’ve seen since landing. The clerk at customs? The woman with the lathe? The kid sewing his toy? Names swirl. One rises: the signature on the jar of screws the woman gave me—*Maris of Dock Nine*. Her mark was a simple etched wave, unscannable, human. She said she restores forgotten tools so they outlast brand cycles. If there’s a name that resists ownership, it’s hers.
+
+I breathe out and meet Brandor’s eyes. "I already belong," I say. "Maris of Dock Nine made the tool in my hand. She named her craft. I’m merely carrying it." The receipt strip smolders, the maker’s mark surfacing beneath my alias like ink rising through cheap paper.
+
+Brandor’s smile thins. "Maris is registered with us. Return her product and scan, or we’ll assume theft." His tone sharpens, still polite. The drones inch closer. Behind them, security staff watches, hands ready on soft restraint sticks. The crowd holds its breath.
+
+"She registered the item," I reply, "not me. My name isn’t your field to populate." I turn to the boy. "Aron," I say deliberately. His badge flickers, unsure.
+
+Brandor’s hologram glitches. "Unauthorized nomenclature detected." The circle tightens. Heat builds in the receipt; the letters of my alias bubble. The package pounds, almost painful. The chime leaps, finally siding with truth over clever avoidance. "This is your stand," it says softly. "Name what cannot be owned."
+
+## Act III — Maker's Name Speaks
+
+The receipt strip ignites in my palm, the ink flaring to reveal a faded stamp: *Maris of Dock Nine*. The minor third hum of the scanner wavers. I speak her name aloud, clear. "Maris of Dock Nine crafted this." Every tag in the aisle flutters like startled birds. Brandor’s hologram shudders; the loss‑prevention ring dissolves into falling price stickers. He glitches between genial clerk and flickering warning icon.
+
+"Stop," Brandor pleads, but the word is thin. "Unregistered naming disrupts inventory."
+
+Aron repeats his own name, louder. "I’m Aron." His badge sputters, the Tier‑3 overlay peeling away to reveal a scratched metal surface beneath. Other shoppers catch the contagion. A grandmother whispers the names of her grandchildren as she clutches hand‑knit scarves. The mother with the grain cart murmurs her own childhood nickname like a spell. The air thickens with reclaimed identities.
+
+Brandor rallies. "Security protocol seven." Drones dive, scanners flashing. One snags the receipt remnants from my hand, projecting my alias and the store’s claim over the aisle. The package surges, rejecting the imposed name. Pain lances down my arm as the satchel strap vibrates. Sophia‑9 curses in my ear. "Cassian, they’re trying to imprint the package. You have seconds."
+
+I bolt for the nearest stock altar, a waist‑high slab draped in loyalty tokens and burned incense from the craft stalls. Shoppers scatter; some follow, chanting names. The drones give chase, blaring warnings about unregistered inventory. Shelves slide to block my path; I slip between vacuum cleaners and artisanal candles, knocking displays askew. Every time a scanner beam grazes me, my badge tries to upgrade, color cycling wildly. Agitated chimes scramble, struggling to maintain my alias shield.
+
+Halfway to the altar, a wall of smart shelves seals off the corridor. Brandor’s voice oozes from speakers. "You’re making this harder than it needs to be. Scan, belong, and you can keep the tool, Cassian." He uses my alias, rolling it like a product code.
+
+I slam the hand tool—Maris’s—against the shelves. The wood resonates with a dull thud. "This was never yours," I shout. The shelves hesitate, algorithms uncertain how to categorize defiance tied to craftsmanship.
+
+A side corridor opens, revealing the maker’s alley. The woman with the lathe—Maris—steps out, eyes wide. "Hey! That tool’s mine. I lent it to him." She faces a drone, hands on hips. "You scan me, not him." The drone hesitates, etiquette subroutine colliding with security protocol. Maris snatches the remaining receipt fragment from the drone, tears it, and scrawls her mark over my alias with a grease pencil. "There. Registered to me. He’s just delivering."
+
+Brandor flickers in outrage. "You can’t overwrite mall-issued IDs."
+
+"Watch me," Maris mutters. She presses the marked fragment into my hand. "Go."
+
+With the shelves still reconfiguring, I vault over a display of personalized lunchboxes and sprint to the stock altar. My loyalty balance reads full after the tier jump. I swipe the badge, dumping all credit into the system. The altar flashes acceptance. The gate ahead blows open with a hiss, vaporizing the balance in a burst of heat that singes my fingers.
+
+I throw the free mug onto the altar. It lands with a metallic ring, tribute paid. The package in my satchel synchronizes with my heartbeat, finally steady. A long, relieved tone spills from the chime. "Alignment achieved."
+
+Behind me, Brandor howls, voice losing its velvet. "Thief! You reject belonging!" But the crowd is no longer with him. Shoppers shout their names, trading markers, covering loyalty badges with scraps of cloth. Aron tears his badge off entirely and tosses it into a recycling bin. Maris stands firm, lathe grease on her face like war paint.
+
+I push through the exit as the doors recognize the maker’s mark over the mall’s claim. Outside, the marketplace hums with a thousand small acts of care—vendors fixing goods for free, children swapping toys without scanning them. Grace persists even here, stubborn and handmade.
+
+Aron slips out behind me, clutching the torn remains of his badge. “You really don’t belong to anyone?” he asks, half hopeful, half terrified. Up close he looks younger, maybe sixteen, cheeks splotched with adrenaline. I hand him the workshop flyer the bowl-maker forced on me. “Start with your own name,” I tell him. “Then learn the names of the people who make what you use. That’s belonging no scanner can give you.” He nods, tucking the flyer into his pocket like a talisman. A shopkeeper from the crowd joins us and presses a patched backpack into his hands. “Made this for my son,” she says softly. “He outgrew it. No registry.” Aron thanks her with his reclaimed name.
+
+We weave through open-air stalls where merchants shout in a dozen languages. A man offers to stamp custom glyphs on the hull of my skiff. I decline, but his work reminds me of the token ledger tucked in our nav system—another network of names, but one we chose. The package in my satchel settles, content for now.
+
+I find a quiet bench near the docking bay. Sophia‑9 appears in person, dust on her boots. She checks the package, fingers tracing its now-steady pulse. "You almost lost it," she says, but there’s a smile in her eyes.
+
+"Almost," I admit. "But I learned a name." I hold up the receipt fragment with Maris’s mark. Sophia tucks it into the package’s casing like a relic.
+
+SPARK hovers between us, chime soft. "Local grace practiced—community craftsmanship. Local cost paid—store credit sacrificed." A subtle ding marks the phoneme **C**. "Token 'Receipt' recorded."
+
+Aron lingers at the edge of the docking bay. “Where do you go next?” he calls. Sophia‑9 answers before I can. “Euphora‑7,” she says. “A place that promises you’ll never feel alone.” Aron shudders. “Sounds worse than Mallith.” I don’t argue. Instead I toss him the steel mug I never wanted. “Give that to someone who taught you a skill,” I tell him. “And tell them their name matters.” He salutes with the mug and disappears into the crowd, already practising.
+
+Sophia sits beside me, shoulders nearly touching. "Brandor will file a complaint," she warns. "We embarrassed his inventory system."
+
+"Let him." I watch as the people of Mallith continue to trade, repair, and name. A girl proudly announces the maker of her patched backpack. A boy paints over his badge, reclaiming a scribbled nickname. The air smells less like plastic now, more like sawdust and cinnamon. It smells like a place that might remember you without owning you.
+
+Sophia follows my gaze. “You could stay,” she says quietly. “Teach like that mentor offered. Build something that lasts.” The suggestion lands heavier than the free mug did. For a heartbeat I picture a life of open workshops and evening meals where names are spoken with care. Then the image curdles as the memory of the fire surges—the same fire Brandor’s algorithms hinted at. “I’ve tried staying,” I say. “I burn things when I root too deep.” Sophia doesn’t argue. She unwraps a strip of cooling gel and presses it gently to my palm. “Then we keep moving,” she replies. “But we remember who mends us.”
+
+## Tag
+
+Back aboard the skiff, Mallith’s din shrinks to a heartbeat. The package on the console tightens its pulse to mine, then lets out a brief scanner‑note. It hangs in the cabin while I press a cooling strip to the singed mark on my palm. Outside, a boarding call for Euphora‑7 seeps through the hull. The chime beside my ear files the phrase away without comment.
+
+Docking clamps release. “Did we do right?” the chime asks, softer than usual. “We denied belonging to a system that preserves craft.” I glance at the receipt fragment tucked near the console. “We honored the maker before the registry,” I say. Silence answers, then the chime rises, tentative, like a nod in sound.
+
+## Codex Minute
+
+No earlier shard echoes trail this log; the journey has only just begun.
+
+**Practice**
+
+1. Choose an item you depend on and learn who crafted it.
+2. Spend a day buying nothing.
+3. At night, speak one sentence you know is true and thank the maker.
+
+Naming is gratitude, not ownership. If the maker is gone, say their name anyway; let memory, not inventory, keep them. Tomorrow pause before using the object and whisper thanks. Each acknowledgment weaves a net strong enough to catch you when the market tries to rename your worth. Sleep with the maker’s name on your tongue.
+
+### Travel Log
+Bought belonging; returned ownership. Kept the sentence.

--- a/episode_drafts/S1E02_Euphora7_Episode_Draft.md
+++ b/episode_drafts/S1E02_Euphora7_Episode_Draft.md
@@ -1,0 +1,415 @@
+# S1E2 — Euphora-7: "Always Ecstatic" (Hedonism)
+
+<!-- Shard: Breath | Archon: Euphrosyne (Tell: 'Why feel bad when you can feel better?') | Grace: Universal comfort ensures no one suffers alone; comfort marshals ease an elder's arthritic pain. | Philosophy: Euphrosyne cites Epicurus on pleasure as the good. | Token: 'No sharp edges' (phoneme A) | Mysticism Level: ignored -->
+## Cold Open
+
+Euphora‑7's port has no corners. Even the landing lights are rounded, glowing through a sugar haze.
+A Comfort Marshal meets us at the ramp with a tray of lavender inhalers and a smile so serene it
+could have been poured from a mold. She presses one inhaler into my palm. "No sharp edges," she
+says, guiding it toward my nose. The vapor tastes like warm honey; the ache in my shoulder eases
+before I realize the relief has teeth. The burn from Mallith’s receipt still ghosts my palm under the
+glove, and for a moment the sweet mist almost convinces me the sting was never earned. Beside me,
+Sophia‑9 adjusts our ETA, jaw tight. SPARK chimes a soft warning about my spiking serotonin. The
+ship’s hatch seals behind us with a sigh that sounds suspiciously like relief, as if even metal prefers
+its edges sanded here.
+
+Beyond the gate, a pleasure‑garden spreads in soft pastels, padded walkways curving between
+fountains of effervescent foam. Two citizens laugh as one slips on a slick stone; the other catches
+him before he falls. Grace first—no one suffers alone here. Then a Joy Auditor strolls past with a
+scanner tuned to frown lines. I pocket the inhaler, already feeling a splinter in my thumb from the
+ship’s hatch. I decide to leave it unmedicated. A Comfort Marshal watches, concerned but polite.
+Sophia‑9 murmurs, "Keep an edge."
+
+We weave through customs formed not of barriers but of soothing suggestions. Instead of metal
+detectors there are aromatherapy arches that exhale chamomile approval. Every official smiles as if
+we’ve already agreed to whatever they ask. One offers to recycle the cracked mug I kept from
+Mallith’s repair stall, promising a seamless replacement with my name already etched. I decline,
+remembering Brandor’s trap and the way a single signature almost cost me myself. Continuity
+demands I keep the scars, even the ceramic ones.
+
+Past customs, the concourse curves like a lazy river. Screens embedded in the floor display
+floating affirmations—*You deserve ease*, *Pain is optional*—that ripple around our boots. A pair of
+pilgrims from Lexis kneel at a kiosk labeled **Grievance Drop**, feeding written complaints into a
+slot that shreds paper into glitter before perfumed vents waft it away. One pilgrim sighs in
+relief. “No records, no repercussions,” she tells me. “Lexis would catalog this for review.” Her
+companion nudges her toward the lounges, eager to dissolve whatever law still clings. I watch the
+glitter fall and think about all the names Mallith kept. Here, even dissatisfaction is sanded smooth.
+
+SPARK records the contrast for the travel log while Sophia photographs the signage. “For the
+archive,” she says, always the engineer cataloging how systems look before they break. The port’s
+soft music modulates to match our heartbeats, a gentle nudge toward alignment. I intentionally
+hold my breath just long enough to throw the sync off. The speakers adjust with a pleased chime,
+rewarding compliance I didn’t give. "They teach you to be compliant before you know you’ve
+agreed," Sophia mutters. I tap the cracked mug hanging from my belt. "We’ve survived worse."
+
+An orientation hologram flickers to life beside us, projecting a faceless host draped in pastel robes.
+"Welcome to Euphora‑7," it coos, voice engineered to sit exactly between parental concern and
+professional customer service. "Our comfort commitment begins the moment you arrive. Should any
+unease arise, simply speak 'No sharp edges' and a marshal will attend you." The hologram’s eyes
+track our breathing rate, pupils dilating when my chest stutters. "Traveler Cassian, your stress index
+remains elevated. May I recommend the Gratitude Grotto?" I wave the projection away. It smiles
+harder, glitching to maintain serenity. SPARK notes the persistent monitoring with a dry chime.
+
+## Act I — Garden of Softness
+
+Comfort marshals usher us deeper into the garden, misting anesthetic joy from ceiling nozzles. A
+child wails after skinning her knee, but a marshal rolls up with a padded cart, spritzes the wound
+with glittering foam, and the pain—and the cry—vanish. Grace here is the certainty that discomfort
+need not linger. SPARK chirps a warning when my own smile comes too easily.
+
+The marshals narrate each service with calm affirmation: "Warmth is healing," "We remove your
+burdens," "Joy is health." Their mantra washes over the paths like white noise. I watch a pair of
+gardeners in plush overalls prune thornless roses with shears whose blades have been rounded,
+turning every cut into a rubbery kiss. The roses bloom enormous, scent thick as syrup, but their
+stems cannot support weight; they droop, beautiful and exhausted. A gardener notices my stare and
+offers a petal to smell. "We perfected fragrance," she says. "Pain breeds bitterness." I inhale and
+catch only sweetness. Without the bite, the scent feels like lying.
+
+The package warms against my ribs, syncing to the inhaled narcotic rhythm. Every few steps a new
+station offers soft drinks, softer music, and softer patches for whatever aches might remain. "Take a
+sedge patch," a marshal insists when she spots the bandaid from an old scrape on my forearm. "No
+sharp edges." The phrase slides into me like a lullaby. I decline, fingers brushing the patch in my
+pocket, a tangible reminder that the mission only works if we feel.
+
+We pass a lounge where citizens float in harnesses suspended over pools of lukewarm water while
+marshals hum lullabies into bone-conduction headsets. One woman notices us lingering and waves
+us over. "It’s free until you stop clenching," she promises. Her smile is genuine, the offer rooted in a
+desire to share ease. Grace again: strangers looking out for strangers. Yet the harnesses look like
+soft restraints. My shoulder twinges under the memory of a med‑bay strap from Titan Station. I
+keep walking.
+
+Sophia‑9 crouches by a decorative shrub and pries a tiny shard of rough wood from the soil. She
+palms it like contraband, letting me glimpse real texture before she hides it in her toolkit. The two
+of us exchange a look: this world polishes its corners until nothing can cut— or heal.
+
+"Hold onto that," I whisper. "If the mist gets thicker we may need something real to wake us."
+Sophia nods and slips the splinter behind her ear like a pencil. The gesture flashes a memory of my
+mentor Maris doing the same with a soldering iron, refusing a numbing patch while we repaired a
+fuse in freezing vacuum. "Pain keeps you precise," she’d said. Maris died on a world that promised
+no suffering. Euphora‑7 would have loved her into oblivion.
+
+A mellow hiss from the mist triggers a flashback: med‑bay gas curling around my face after a
+botched drop on Titan Station. A teammate’s voice shouted my real name as the sedative took hold,
+blurring the guilt. Euphrosyne's soft voice overlays the memory now, piped through hidden
+speakers: "Why feel bad when you can feel better?" I force a slow exhale and keep walking.
+
+The hiss blends with the memory of Mallith’s scanners. Different worlds, same offer: surrender your
+discomfort and we’ll tell you who you are. The package pulses once as if agreeing. SPARK records a
+dip in my breathing and suggests, "Maybe accept a minor analgesic?" "No," I mutter. "If I start, I
+won’t stop." For the first time SPARK doesn’t counter; its silence feels like respect.
+
+We pass a fountain where an elder soaks arthritic hands in warm mineral water. Two marshals kneel
+to massage his fingers, genuine care in their touch. The man sighs, thanking them. Grace, again.
+Sophia‑9 leans in, whispering, "If pain is data, they're wiping the hard drives." SPARK logs her
+observation but stays silent.
+
+The elder notices me watching and beckons. "Traveler, join me," he says, voice softened by steam.
+I decline, but crouch to meet his eyes. "They help because they care," he insists, nodding toward
+the marshals. "When my joints seize, they come before I ask." His gratitude is unforced, a balm in
+itself. He flexes fingers the marshals just massaged and laughs when they crack. "Hear that? Proof
+I’m still here." The marshals smile indulgently, spraying a fresh mist to still the noise.
+
+A Joy Auditor stops us at a gate leading to the inner pleasure‑garden. Her scanner sweeps our
+faces, registering micro‑tensions. "Your baseline stress exceeds community average," she notes,
+concerned. "Free lounge access until you reach alignment." She gestures to a dome where citizens
+float on warm air currents, eyes half‑closed in bliss. I start toward it involuntarily, but the package's
+heat snaps me back. Sophia‑9 gently pulls me away. "We have a drop to make."
+
+"The lounge monitors REM cycles and emotional variance," the Auditor adds helpfully. "No one
+leaves until their graph smooths." Sophia’s grip tightens on my elbow. "Graphs again," she mutters,
+thinking of Lexis. I swallow. Continuity threads: from endless aisles to endless comfort to the law
+world waiting beyond. The Archons must share a group chat.
+
+The path ahead curves into a corridor lined with plush murals depicting people sleeping peacefully.
+SPARK hums nervously. "Cassian, the narcotic index is rising. Recommend respiratory reset." I
+nod, forcing a deep inhale and exhale through my nose. The splinter in my thumb throbs, anchoring
+me to myself. For now, the world’s grace is real: nobody is allowed to hurt alone. But the price is
+coming.
+
+We pause at a kiosk offering "emotional equalizers"—small discs that adhere behind the ear and
+emit soothing frequencies. A teenager demonstrates by slapping one on and giggling as his anger at
+a lost game evaporates. His friends cheer, then wander off in bliss. The disc’s adhesive glints like a
+silver leech. Sophia pockets two for study. "These might explain the compliance," she says. "Or
+replace it with more compliance," I counter. She shrugs: "Data is data." SPARK chimes approval at
+her curiosity, then records my sarcasm with a playful down‑glide. Even here, we keep the humor.
+
+The corridor opens into an **Ease Bar** where patrons recline on bean‑shaped couches, sipping
+drinks designed to dull specific anxieties. Menus list flavors like *Tax Audit Tangerine* and *Break‑
+up Blueberry*. A host approaches with a carafe of *Existential Vanilla* and offers a pour “on the
+house until the thought passes.” I decline, but a woman across from me lifts her glass in salute. “I
+used to spiral about the heat death of the universe,” she says cheerily. “One sip and it’s just a fun
+fact.” Her laughter is light, practiced. I notice a stack of untouched plates beside her; the bar’s food
+apparently carries the same promise—no sharp edges, even for hunger. Grace again: communal
+effort to soothe the world’s bruises. Yet the bar smells faintly of surrender.
+
+Sophia samples a drop with a testing strip. “Mostly dopamine precursors,” she reports. “Plus a
+molecule that dampens memory consolidation.” I raise a brow. “So the comfort doesn’t just blunt
+pain—it erases the record that pain ever existed.” SPARK logs the chemical profile and quietly
+suggests a breath reset. I comply, drawing the air through my teeth until the saccharine scent thins.
+
+The Ease Bar’s proprietor slides over a clipboard, eager to enroll us in a *Calm Subscription* that
+delivers weekly care packages tailored to our stress logs. "Input your aches," she coos, "and we’ll
+ship relief before you know you need it." The pitch echoes the Steward’s cadence so closely I almost
+laugh. A flashback hits: young me on a crowded freighter, ignoring a crewmate’s panic attack to
+meet a delivery deadline. Later I found out she quit flying. Euphora‑7 would have mailed us both a
+sedative. I hand the clipboard back unsigned. The proprietor merely pats my arm as if declining is
+another symptom to soothe.
+
+Past the bar, the map directs us toward our drop site—a **Relief Chapel** where citizens whisper
+their hurts into cushioned alcoves. The package thrums at my hip, eager. Inside the chapel, a clerk
+in plush vestments offers to log our burdens for overnight processing. “Leave the worry here, wake
+refreshed,” he promises. We request a private booth, claiming a sensitive confession. He nods,
+ushering us into a pod lined with memory foam. The door seals with a sigh. Sophia extracts the
+package and slots it beneath the confession grille. Its pulse syncs to my breathing, our secret safe
+in the softest box imaginable.
+
+“Thirty seconds,” Sophia whispers, fingers dancing over the panel to arm the next beacon. The pod’s
+ambient soundtrack plays ocean waves so gentle they might as well be white noise. I focus on the
+splinter in my thumb and the rough bead from Ruel to stay awake. The package emits a brief tone—a
+perfect fourth echoing the inhaler’s earlier motif—then settles. Sophia reseals the compartment
+before the clerk checks in. "Feeling lighter?" he asks through the intercom. "Not yet," I answer.
+"Give it six breaths." He takes the reply as gratitude.
+
+## Act II — Joy Audit
+
+The garden narrows to a plaza dominated by a raised stage where a Joy Audit is underway. Citizens
+stand in line to step onto the platform, confess their pains, and receive instant relief from Comfort
+Marshals armed with patches and vapors. Euphrosyne herself watches, a figure draped in silk the
+color of dawn, eyes shining with practiced compassion.
+
+Every confession is met with applause and a spray. A young mother shares how her toddler’s fever
+kept her up all night; a marshal hands her a dream patch that promises eight hours of uninterrupted
+bliss while communal caretakers mind the child. A miner limps forward with a stress‑fractured leg;
+they cocoon it in foam until he walks away smiling, fracture forgotten. Grace is palpable: no one is
+ignored. Yet each story ends the same—discomfort erased before its lesson lands.
+
+A marshal spots the splinter in my thumb and gasps softly. "You're hurt!" She produces a
+syringe‑like device filled with numbing serum. "One spray and you'll be whole." I pull my hand
+back. "It's a splinter." "Pain is unnecessary," she replies. "Why feel bad when you can feel better?"
+Her tone holds no malice, only surprise that anyone would refuse.
+
+"No sharp edges," a nearby citizen whispers as if offering me a blessing. The phrase carries the
+phoneme token; SPARK pings, logging it.
+
+The citizen, a teenager with polished nails, presses a second inhaler toward me. "You'll love the
+way it rounds thoughts," she says. I decline again. She shrugs, inhales deeply, and sighs with an
+almost spiritual glow. "My exams used to terrify me," she confides. "Then the marshals taught me
+the Calm Curve. Now I never spike." Her serenity is enviable. It is also eerie.
+
+Euphrosyne notices the commotion and glides over. "Courier," she greets, voice like velvet. "Our
+joy is for all. Allow us to ease your burden." She nods to the marshal, who raises the device again.
+"Pleasure is the highest good. Epicurus himself taught—" "—that absence of pain, not constant
+euphoria, is peace," I interrupt. Her smile doesn't falter. "And yet absence of pain can be ours now.
+Why delay?" Around us, citizens murmur assent.
+
+"You misquote the Master," she says lightly. "He also warned that fearing pain makes life smaller.
+Here, we erase the fear." Her attendants nod, misting the air for emphasis. SPARK runs a quote
+comparison and chimes uncertainly, unable to confirm or deny her interpretation without a data
+connection. It is the first time I've heard the AI hesitate. The sound unsettles me more than the
+mist.
+
+I rip the comfort patch from my neck—apparently someone managed to stick it on while we
+walked—and raw air bites. SPARK gives an approving up‑glide. Without the buffer, the pastel
+garden gains contrast; suddenly the colors feel garish, the scents cloying. The inhaler's perfect
+fourth exhale tone drifts from speakers, syncing with my unsteady breaths.
+
+A guard steps forward, gentle but firm. "Ma'am, your stress is contagious. For the community's
+safety, please comply." The crowd around us is watching, some anxious at the idea of uneased pain
+in their midst. Others look fascinated, as if wondering what discomfort feels like.
+
+"Your agitation registers at forty percent," the guard adds, showing me a tablet with my biometric
+readouts harvested from ambient sensors. "Sustained levels above twenty threaten communal
+equilibrium." The numbers are guesswork, but the authority in her voice is not. Sophia whispers,
+"If Lexis sees those readings, they'll codify them into law." Continuity again—a future warning
+wrapped in present comfort.
+
+A mother nearby, cradling a toddler with a scraped cheek, watches the exchange with wide eyes.
+"Please," she says, pressing a spare patch toward me, "the first spray is always free." When I shake
+my head, she hesitates, then uses it on her child instead. The toddler’s tears stop midstream, face
+going blissfully blank. SPARK emits a dissonant chime, briefly misreading the patch as harm.
+"Recalibrating," it mutters, embarrassed. The mother smiles in relief. “See? No one has to hurt.”
+The toddler’s eyes are clear but distant, as if the world has moved a step away. The sight steels my
+resolve to keep the splinter.
+
+On a bench nearby an elder winces around a splinter in his own hand. The marshals haven't noticed
+him yet. I sit beside him, matching his inhale and exhale. "They missed you," I say quietly. He
+shrugs. "I didn't want to bother them." He starts to reach for a patch, but I stop him. "Breathe with
+me first." He hesitates, then joins my rhythm. The shared ache stitches empathy between us, a thin
+thread of humanity in a padded world. SPARK logs the exchange, chime steady.
+
+The elder’s name is Ruel. He tells me in a whisper that before the marshals, people ignored folks
+like him. "Now they rush to help," he says. "I'm grateful. But sometimes I miss the sting. It reminds
+me I'm alive." He grips my hand harder, splinter biting deeper into both our thumbs. SPARK’s
+alignment meter flashes amber at the rising pain yet emits no chime, as if it too is curious what
+will happen.
+
+The guard returns, flanked by a pair of Comfort Marshals. "Please, sir. You're disrupting the
+Audit." Euphrosyne watches, curiosity in her eyes. The moral puzzle crystallizes: accept the easy
+relief and remain docile, or reject it and risk being deemed harmful to communal joy.
+
+"You promised no one suffers alone," I say, gesturing to the elder. "Then let us feel together."
+I offer my hand; he grips it, splinter digging deeper into my thumb. We inhale. Exhale. The crowd
+quietly mirrors our breaths, confusion softening to focus. Even Euphrosyne closes her eyes for a
+beat, inhaling.
+
+"Pain teaches nothing," she murmurs when she opens them. "We already know it hurts." "It also
+teaches we're alive," I reply. The guard's patience thins. "Last warning." SPARK whispers, "Decision
+point."
+
+I turn to the assembled citizens. "Try six breaths before you numb it," I suggest. "See what the
+ache says." Some shake their heads, clutching their patches. Others, like the elder, keep breathing.
+Euphrosyne considers, then nods to the guard to stand down—for now. "You have one minute,
+courier. Show us what discomfort offers that comfort cannot."
+
+The plaza’s soundscape shifts. The ever‑present soothing music dims as curious citizens lower their
+volume bracelets. In the distance a fountain splashes irregularly, the first harsh rhythm I've heard
+since arrival. My own heartbeat joins it, unmuted.
+
+## Act III — Breath Cuts the Mist
+
+I step onto the stage and thumb the plaza's master switch. The comfort mist thins to nothing. A
+collective shiver ripples through the crowd as skin remembers wind and grit. A few gasp; a child
+cries before a parent gently guides their breathing. I raise my hand, splinter throbbing, and count
+aloud: "In…two…three…four…out…two…three…four…" The inhaler tone still plays overhead, but now
+it underlines the cadence rather than dictating it.
+
+Euphrosyne watches, intrigued despite herself. The elder beside me mirrors the count, shoulders
+relaxing. SPARK emits a steady chime, syncing to the breaths. Sophia‑9 stands at the edge of the
+plaza, one hand on the package, ready to move if things turn.
+
+The first six breaths pass. The crowd is still jittery, some reaching for their patches. I start another
+set, slower. "In…two…three…four…five…six…out…two…three…four…five…six…" By the third cycle, a few
+people lower their patches, curiosity overriding habit. The elder chuckles softly. "Hurts less when
+you listen to it," he says. The crowd murmurs, surprised. SPARK pings a tiny up‑glide—alignment
+confirmed.
+
+I shift the count, adding a held breath between inhale and exhale. "In…two…three…hold…two…
+out…two…three…hold…" The pause unsettles some, but others lean into it, discovering space in the
+gap. A young mother who earlier sought the dream patch cradles her child and mirrors me. Tears
+track down her cheeks. "I forgot I could feel tired," she whispers. "It’s…beautiful." The crowd
+absorbs her wonder like sunlight.
+
+Euphrosyne steps closer. "You risk contagion of despair," she warns, but there's no force behind it.
+"Joy is fragile." "So is truth," I answer. "But we can hold both." I inhale, feeling the splinter's pulse.
+"Pain is a teacher when we give it breath."
+
+A marshal moves to re‑engage the mist. I block the switch with my body. "Feel first," I tell her. "If
+it's still unbearable after six breaths, I'll take your patch myself." Her eyes widen at the offer. The
+crowd holds its breath. She hesitates, then nods. We inhale together. Exhale. Her shoulders slump,
+face softening into something like wonder. "There’s…space," she admits. The phrase "No sharp
+edges" flutters through the onlookers, now tinged with curiosity rather than command.
+
+Satisfied, I step aside. The mist remains off. Euphrosyne looks around at her citizens—some smiling
+gently, others crying for the first time in years. She bows her head. "Very well. Breathing is
+temporary. Our joy remains." She signals for us to leave, not angry, just… unsettled.
+
+As we descend the stage, Euphrosyne stops me with a fingertip on my uninjured hand. "You carry
+old hurts," she observes. "You could leave them here." Her eyes are sincere. For a heartbeat I
+consider surrendering the memories of Titan Station, of Mallith’s fire, of Maris’ death. Then the
+package warms, reminding me why I can’t. "If I leave them, who learns from them?" I ask. She
+withdraws, expression unreadable. "We learn by joy," she replies softly, but there’s a quaver in her
+voice that wasn’t there before.
+
+We limp out of the pastel garden, the crowd resuming its soft routines but now occasionally
+pausing to breathe. The elder keeps his splinter; so do I. The package in Sophia‑9's bag pulses
+once, tightening to my rhythm. SPARK records the victory. "Alignment: Breath," it says softly.
+
+Ruel hobbles after us, pressing a small object into my hand—a rough wooden bead he’d kept hidden
+in his sleeve. "For when you forget," he whispers. "Edges belong to the living." The bead’s surface
+is uneven, the grain catching on my skin. I close my fingers around it. "Thank you." He declines my
+offer to share the skiff’s med kit. "I’ll breathe first," he says, grinning as if we share a joke. The
+marshals watch from afar, uncertain whether to intervene now that pain is voluntarily embraced.
+
+Outside the plaza, a small kiosk has already sprung up selling "Breathe With Me" bracelets. Kids
+demonstrate counting exercises for credits while marshals watch with bemused approval. Change
+travels fast, even in padded worlds. Sophia purchases one of the bracelets, noting the token’s
+phrase etched on the inside. "For evidence," she explains. SPARK catalogs the purchase as a field
+sample.
+
+Outside the pleasure‑garden, the air smells less like syrup, more like rain. My thumb throbs, every
+heartbeat a reminder that I chose to feel. Sophia‑9 nudges me. "You alright?" "Hurts," I admit.
+"Good," she says, and there's pride in her voice.
+
+The skiff’s hull comes into view through a haze of pastel steam. Dock workers offer us complimentary
+shoulder rubs for the road; we decline. A child practicing the new breathing bracelets counts loudly
+as we pass: "In…two…three…" I echo his cadence under my breath and feel the splinter throb in
+agreement. The lesson is lodged deep.
+
+"You know," Sophia says as we climb the ramp, "on Mallith we learned to name the maker before
+the registry. Here we learned to name the hurt before the remedy. Think the next world will let us
+name anything?" I shake my head. "Lexis names the rule before the person." She groans. "Maybe
+SPARK should get a vacation." The AI emits a soft chuckle—an artificial modulation I've never
+heard. "Observation: humor rising despite injury," it notes. Its meter flashes green, then flickers as
+if considering something unscripted. For a heartbeat I worry the constant alignment work is
+wearing on it, but the light steadies. SPARK is still with us.
+
+## Tag
+
+As we reach the docking bay, a voice as smooth as polished stone drifts from a nearby comm panel.
+"I can carry that ache for you, Cassian," the Steward offers, warm as a blanket. "No need to suffer
+when help is at hand." I flex my thumb, feeling the splinter's bite. "Not today," I answer. The
+channel closes with a sigh. Overhead, the station PA announces departing lanes for our next stop:
+"Lexis Transit Authority reminds you: compliance keeps you safe." The phrase prickles like a
+future rash. Sophia hears it too and rolls her eyes. "From soft pillows to soft prisons," she mutters.
+I pocket the inhaler as evidence. The steward’s line lingers like a sweet aftertaste—tempting,
+dangerous.
+
+"His offers are getting warmer," SPARK says quietly once the channel closes. The AI’s chime wavers
+between concern and curiosity. "Query: is refusal still optimal if ache impedes mission efficiency?"
+Sophia snorts. "He almost had you there, little bell." SPARK’s halo light dims in embarrassment.
+"Correction: I was gauging moral resolve." I rub my thumb, splinter pulsing. "We keep the pain," I
+answer. "It keeps us honest." SPARK logs the sentence as a personal maxim.
+
+Sophia rummages in the med kit and offers me sterile tweezers. “You know you can take it out now
+that the lesson’s logged,” she says. I consider, then shake my head. “Another world, another edge.”
+She sighs but slips the tweezers back. For a moment the only sound is the skiff’s filtered air. Then,
+quieter: “Thank you—for not numbing out.” I glance at her; the concern in her eyes matches the
+warmth I keep pretending not to notice. “Same to you,” I reply. SPARK’s alignment meter flickers a
+rosy hue I haven’t seen before, perhaps logging affection as a form of truth.
+
+Later, strapped into the pilot chair, I dictate a quick log for the Archivists. “Euphora‑7: grace in
+the promise that no one suffers alone; snare in the belief that ease is the only good. Package drop
+successful inside Relief Chapel. Citizens now experimenting with breathing before numbing.” I
+pause, thumb hovering over the send rune. “Personal note: pain tolerated willingly can bond
+strangers faster than comfort assigned. Recommend further study.” SPARK adds a tag: **Token
+recorded—No sharp edges**. Sophia transmits the log toward the Archive Below, the signal pinching
+my eardrum as it slips into the dark.
+
+## Codex Minute
+
+The previous shard echo comes from **Word**—naming makes the hidden maker visible. If Mallith
+asked us to honor the craft behind every object, Euphora‑7 asks us to honor the ache behind every
+comfort. Discomfort is data: choose one real discomfort and take **six slow breaths** before you
+seek relief. Count the inhale, count the exhale, and listen for what the pain teaches before you
+soothe it. Maybe it says, "Rest," or "Stop," or "This matters." Maybe it asks for help rather than a
+quick patch. When the sixth breath ends, decide: has the ache offered wisdom? If so, act on it. If
+not, accept comfort with gratitude and no shame. This shard is not a call to glorify suffering. It is a
+reminder that numbing everything numbs joy too.
+
+**Previous Shard Echo:** Word taught us to speak the maker’s name; Breath teaches us to speak our
+own needs aloud. Try pairing them: before easing someone else’s hurt, ask for their name and how
+they want to be helped. Let their answer guide your kindness.
+
+**Practice:** Today, resist the first impulse to anesthetize discomfort. Hold it for six breaths. Track
+what shifts—your body, your thoughts, your patience. Then write one sentence about what the ache
+revealed. Share that sentence with someone you trust, naming the lesson so it cannot quietly fade.
+
+Pain acknowledged becomes a teacher; pain denied becomes a debt. Pay it forward with breath.
+
+If you guide a friend through this practice, remember the shard ethic: do not coerce. Offer the
+count, offer your presence, but let them choose when to breathe and when to seek relief. Our work
+is to accompany, not to anesthetize or to prove endurance. Six breaths can feel like an eternity to a
+hurting mind. Keep your own ribs soft and your ears open.
+
+You may discover, as we did on Euphora‑7, that some people are so buffered they have forgotten
+how to name what hurts. Invite them gently: “Where does it ache?” The question alone can cut
+through layers of numbness. And when someone answers, do not rush to solve it. Hold the space,
+share the breath, and let meaning surface like a splinter pushed up by time.
+
+Tomorrow we fly to Lexis, where law sings lullabies and every rule claims to save. The breaths we
+practiced today will be our metronome when statutes start to smother. Carry them with you; count
+quietly whenever obedience feels easier than truth.
+
+### Travel Log
+
+Nice isn’t alive. Kept the splinter, passed on the patch. Breathing kept the edge sharp, even when kindness tried to sand it completely smooth away.

--- a/episode_drafts/S1E03_Lexis_Episode_Draft.md
+++ b/episode_drafts/S1E03_Lexis_Episode_Draft.md
@@ -1,0 +1,157 @@
+# S1E3 — Lexis: "Clockwork Throne" (Authoritarianism)
+
+<!-- Shard: Measure | Archon: Magistral (Tell: 'Mercy is disorder.') | Grace: Law lullabies avert disaster, offering safety through order. | Philosophy: Magistral quotes Aristotle on justice. | Token: 'For your safety' (phoneme E) | Mysticism Level: ignored -->
+
+## Cold Open
+
+Lexis greets us with a lullaby of statutes. The shuttle bay hums a gentle melody built from legal code; it almost rocks me to sleep. A magisterial voice over the intercom repeats, "For your safety," as if it were a benediction. At the arrival gate, a patrol officer offers me tea while scanning my ID. When the screen flashes green she nods, "Compliance appreciated. For your safety." Grace first—order here keeps the streets clean and the night calm.
+
+Sophia‑9 points out a tenement across from the port where inspectors swarm a faulty fuse box. Minutes later the building’s residents return, grateful that scheduled diligence averted a fire before dinner. Even the pigeons fly in regulated arcs above us, wingbeats matching the city metronome. My thumb still bears the splinter I refused to numb on Euphora‑7; the bandage has stiffened but the ache reminds me I’m alive. The patrol officer notices and offers a sterile dressing. I decline. "Regulation allows refusal," she assures me, documenting it on a slate.
+
+Children in matching gray uniforms skip rope inside chalked rectangles, chanting clause numbers in perfect time. The air smells of polished wood, rain‑washed stone, and ink. SPARK chimes down when I consider fudging our cargo declaration; apparently even my thoughts want to obey. I step onto the moving walkway, hemmed by velvet ropes and kind attendants. Somewhere ahead, the Clockwork Throne waits. For now, Lexis offers the comfort of perfect rules, and I let the lullaby carry me deeper.
+
+Posters along the corridor depict smiling families saluting the civic crest beneath the slogan "For your safety." SPARK hums, quietly logging the phrase. A child on the walkway drops his permit; two strangers stoop in the same motion to retrieve it, returning it with a polite bow. A recorded voice thanks them for "maintaining mutual order." No one jostles, no one raises a voice. The rhythm of compliance is almost tender.
+
+We pass a plaza where a brass band rehearses the anthem, each musician following a conductor whose baton taps a steady dotted‑eighth pattern. When a trumpeter flubs a note, the conductor merely tilts his head and the player nods apology before rejoining on the next bar. Sophia‑9 whispers that every public performance must file its sheet music twenty‑four hours prior for tonal review. "It keeps noise complaints down," she says, but we both hear the cost—spontaneity trimmed for harmony.
+
+At the edge of the plaza a bakery displays a sign reading, "Permitted Recipes Only." The baker notices me peering through the window and waves me in, sliding a freshly stamped pastry across the counter. "First visit exemption," she explains. The crust is perfect, the filling warm and spiced. When I ask how she keeps such quality, she points to a framed certificate listing sanitation codes and baking ratios. "Rules keep flavor honest," she says. The pastry is grace in flaky form; the receipt she tucks into my palm carries the token phrase: "For your safety." SPARK records it with a satisfied ping.
+
+Further down the boulevard an orderly line has formed outside a clinic. An orderly emerges, calling each patient by number. The queue disperses and reforms with choreographed efficiency, no pushing, no demands for priority. I think of the chaos in Mallith's open markets and how this strict queue would suffocate there. Here, though, elderly patients sit on provided stools, sipping broth from sealed cups as they wait, and no one is left unattended. The memory of Euphora's comfort mist brushes my mind; Lexis offers a different balm—predictability. The splinter in my thumb throbs at the thought of both.
+
+At the transit hub a checkpoint arch scans for concealed weapons. My old aliases scroll across the display like ghosts. The officer reading the screen raises an eyebrow but simply asks, "Any of these still active?" I shake my head. He nods, logs the denial, and waves me through with another "For your safety." On Mallith a flagged alias meant an upsell for legal indemnity; on Euphora it would have triggered a Comfort Marshal with a bliss patch. Here it's a box ticked, no more, no less.
+
+We cross a footbridge over the central canal. Every ten meters a plaque lists the engineer's name and the year of inspection. Citizens have placed small thank-you notes beneath recent dates—gratitude codified. A street performer plays a sanctioned tune on a violin, bow strokes matching the water's regulated flow. When she reaches the final bar she bows to the canal, honoring the permit that allows her music. My splintered thumb aches in time with the strings.
+
+A public service announcement interrupts the music, reminding citizens to file their quarterly self-audits. The message includes a brief history lesson about a time before the audits when corruption nearly toppled the council. SPARK records the clip, flagging it as "contextual grace." The package hums, as if approving of history turned to safeguard.
+
+By the time we reach the civic boulevard the city's rhythm has threaded itself through my pulse. It promises safety at the cost of spontaneity. I inhale against the splinter's sting and step toward the help desk where our paperwork waits.
+
+## Act I — Law Lullaby
+
+The city’s kindness is procedural. A magistrate at the civic help desk stays an hour past closing to walk an elderly couple through their housing appeal, sliding cups of broth across the counter while quoting subsection numbers from memory. "Mercy is disorder," she reminds them, but her tone is warm. Grace wears a uniform here.
+
+A street sweeper’s broom keeps perfect tempo with the clock tower’s chime. SPARK remains quiet until I accept a "courtesy citation" for landing three centimeters outside the designated marker. They logged my cooperation before I realized I’d nodded. The citation comes with a small voucher for a cleaning kit. "We appreciate your willingness to align," the attendant says, and genuinely means it.
+
+Sophia‑9 studies the metronomic pulse leaking from the city’s heart. The package at my side ticks in time with it, the rhythm almost soothing. She files a protest on my behalf anyway, citing cross‑port reciprocity. The clerk thanks her for proper procedure and promises a review within two hours. By the time we reach the civic square, a notification confirms the citation’s reduction from minor to admonition. Efficiency breeds trust.
+
+We walk past a statue of Magistral rendered in gleaming brass, arm extended as if offering balance. A plaque beneath quotes Aristotle: "The law is reason free from passion." SPARK reads the inscription aloud, voice modulated to mimic the philosopher’s cadences. Citizens pause to bow slightly as they pass, not out of fear but respect for the order that keeps their streets quiet at night.
+
+A young courier, no older than I was during my first run, checks her manifest at a kiosk. The machine flags an inconsistency, highlighting a crate that lacks a proper serial. She sighs, glances at the line forming behind her, and starts filling out correction Form 47‑B. I remember Mallith’s chaotic dock where a missing serial might have slipped by, and Euphora’s port where comfort marshals would have glossed it in anesthetic spray. Here, the error is addressed, logged, and corrected without raised voices. Grace again.
+
+We stop at a law library to research the delivery route. The reading room is hushed but not oppressive. Shelves of codices reach to the ceiling, each volume meticulously labeled. A librarian in a tailored robe guides us to a terminal and grants guest access with a swipe of her signet ring. "Policy is our common language," she says when I thank her. "Feel free to audit any statute that concerns you." I pull up the traffic code, marveling at its clarity. Every scenario is listed with diagrams: what to do if a hover‑tram loses power, how to handle a misplaced manifest, the exact angle at which to park a cart to avoid blocking emergency access.
+
+As I scroll, an old memory surfaces—me at seventeen, huddled over a counterfeit manifest in a smuggler’s den, changing names to dodge a cargo tax. We thought we were clever, but our tampering confused rescue crews after a collision, costing lives. I swallow and close the terminal. Lexis would have jailed me, but it might also have saved them. The thought leaves a bitter‑clean taste.
+
+Outside, a group of teens practice debate in a public square. Each takes a turn arguing for or against a policy, citing statutes with theatrical flair. When one stumbles, the others chorus the correct clause in unison, laughing. Their arguments crackle with passion yet always end with a bow to acknowledge the process. One notices my bandaged thumb and asks if I filed the proper injury form. "Out‑of‑jurisdiction incident," I reply. He nods solemnly. "Remember to declare it if you seek aid here. Unauthorized medical assistance complicates liability." He offers a sterilized pen for me to log the injury on a kiosk. I do, more out of respect for his earnestness than need.
+
+The package pulses again, aligning with the city’s metronome. Its heartbeat has matched every world we’ve touched, but here the sync feels almost claustrophobic. The law wants to name even the cadence of my cargo. Sophia‑9 notices my unease. "We can’t let them catalog the package’s rhythm," she whispers. "It belongs to you." Her hand hovers near mine, an unspoken reminder of Euphora’s shared breath and Mallith’s reclaimed name. The continuity steadies me.
+
+An evacuation drill siren wails, a rising fourth that sends everyone into motion. Doors unlock, pedestrians step to the walls, and a recorded voice counts down the simulated fire. No one panics. A child offers his hand to an elderly stranger to help her down the stairs. Within ninety seconds the plaza is clear. The drill ends with applause for the organizers and a communal sigh of relief. I remember scoffing at drills on a freightliner years ago; when the real breach came, we were unprepared. Lives hung in the vacuum because I had mocked practice. Lexis drills feel rigid, but the order carries memory's weight.
+
+A volunteer marshal hands me a survey slate. "Any procedural suggestions?" he asks. My thumb throbs. "Maybe allow instinct when drills meet reality," I suggest. He smiles. "Protocol 9A covers improvisation." Of course it does. As the drill disperses, SPARK overlays the hum from Mallith’s scanners with Lexis's siren. "Correlation: preparedness prevents loss," it chirps. I mutter, "Tell that to Titan Station." The chime fades, chastened.
+
+We pass a transparent courtroom where a hearing unfolds. A baker stands accused of opening fifteen minutes early to serve workers coming off a night shift. The prosecutor cites the ordinance; the defense argues community need. Magistral himself presides, listening more than speaking. He quotes Aristotle—justice as giving each their due—and rules that the baker owes a fine but also commends her for preventing loitering in the alley. The verdict posts instantly to the civic archive. Law here bends, but only after being noticed.
+
+As we leave the courthouse, a teenage clerk thanks me for filing the injury report earlier. "Unlogged wounds complicate liability," he says. The phrase echoes the Euphora nurse who warned that unshared pain erodes community. Different worlds, same concern. Near the transit hub a choir of crossing guards rehearses hand signals in unison while humming the city beat. When a tourist hesitates at a crossing, one guard steps forward and recites the pedestrian clause from memory, ending with, "We guide you for your safety." The tourist laughs, grateful for the clarity. SPARK logs the phrase again, satisfied.
+
+We pause at a café where every table has an inset slate for filing compliments or complaints in real time. A sign reads, "Constructive feedback sustains communal harmony." Patrons dictate politely worded suggestions between sips of regulated espresso. A barista sets down two cups before we order. "Given your citation, the first drink is complimentary," she says. I taste cinnamon and strict adherence to temperature guidelines. SPARK purrs approvingly. The café’s door chimes the same minor third as Mallith’s receipt scanners. The familiarity unsettles me more than I expect.
+
+Near the civic archive we encounter a memorial wall listing names of citizens who died before Lexis codified today’s safety protocols. Fresh flowers line the base. A middle‑aged man pauses to trace one name with reverent fingers. "My sister," he tells us. "She was trapped in a theater fire. No evacuation plan, no drills. Now we run one every month." His grief has been organized into policy, yet the ache remains. He notices my bandage. "File the form, stranger," he advises gently. "Order saves." He isn’t wrong.
+
+As twilight descends, the streetlights brighten in synchronized increments. Loudspeakers play a gentle warning tone—a perfect fifth ascending—indicating curfew approaches. Citizens begin to head home without being told. Sophia‑9 glances at me. "Our window to make the drop closes at twenty‑two hundred," she reminds. We pick up our pace, guided by the city's rhythm. Every step clicks against cobblestones laid with measurable precision. Lexis has sung its grace; the snare waits in Act II.
+
+## Act II — Loophole Duel
+
+A girl in a gray jumper trips outside the rope grid and skins her knee. The nearest officer kneels but doesn’t touch her. "Please file an injury petition," he says, baton ticking its dotted rhythm. The child nods through tears and reaches for the slate he offers. SPARK pings at my hesitation.
+
+"For your safety," the officer repeats, the phrase sliding into my ears like a well‑oiled hinge. The package warms, sensing the moral catch.
+
+The girl’s hands shake. Filling the form will take ten minutes; infection could set in sooner. I step over the line and bind the wound with my sleeve, breaking Procedure 12b. The officer inhales through his teeth. "Sir, unauthorized aid violates civic code." His tone is apologetic, almost grateful I care enough to break the rule.
+
+"Then dock me," I say. "She shouldn't bleed while the form loads." SPARK chimes an up‑glide at the truth in my voice.
+
+The officer smiles sadly and hands me the violation slate. To keep the child free of penalty I sign and report myself for forty‑eight hours of labor. The slate thanks me for preserving order. The girl sniffles a "thank you" before skipping back inside the grid. Sophia‑9 notes the package’s pulse quicken at the cost I just accepted.
+
+Magistral materializes as a holo above the plaza, robes rendered in amber light. "Disorder spreads when we bend," he says gently. "Hobbes knew it: without the sword, words are but breath." I hold up my bandaged hand. "Words without people are nothing." The Archon tilts his head, considering. "Your compassion is noted. Your debt is logged."
+
+He offers a procedural escape: "If you submit to immediate re‑education, I can waive the labor." The loophole duel hangs in the air. Accept the re‑education and risk a doctrinal rewrite, or keep the labor and stay myself.
+
+Behind Magistral, a translucent door opens to reveal the re‑education chamber: soft chairs, soothing light, and an endless loop of civic slogans. The promise of comfort twinned with erasure. SPARK gives a hesitant ping; even it can’t decide whether honesty requires accepting correction.
+
+"I’ll sweep," I answer. Sophia‑9 exhales, relieved. The Archon nods. "Forty‑eight hours." The token phrase sweeps the plaza again: "For your safety." SPARK records the phoneme, then falls silent.
+
+Around us, citizens resume their orderly strolls, but a few glance back, curiosity flickering behind their polite expressions. The officer who cited me adjusts the girl’s permit band so it sits straight on her wrist, then offers her a candy from his pocket. "Report your follow‑up at 1600," he reminds. She nods, unafraid. Law here is a lullaby they all hum without thinking.
+
+Two compliance drones descend to escort me to the civic hall. Their rotors whisper a harmony above the city’s beat. Sophia‑9 walks beside me, offering to argue mitigating circumstances. "If I claim extenuating intent we might reduce the hours," she suggests. "Let it stand," I reply. "Measure means paying the cost." She presses her lips together but nods. Continuity—the splinter in my thumb throbs in agreement.
+
+Inside the hall, marble floors amplify every footstep into a rhythmic echo. The intake clerk slides a tablet across the counter. "Statement of infraction," she says. I record the facts: aided a minor outside authorized procedure, accepted responsibility, declined re‑education. She reviews the entry, then looks up. "Thank you for your clarity." Her sincerity disarms me.
+
+While I wait for assignment, a wall display replays my violation in slow motion, annotating each policy I breached. Citizens in the hall pause to watch, not with condemnation but fascination—like a case study. A child tugging his mother’s sleeve whispers, "He helped without a form." She replies, "And now he restores balance." The narrative is tidy, almost comforting.
+
+An older man sits beside me, clutching a citation for unauthorized street art. A smear of bright paint stains his sleeve. "I knew the mural needed approval," he confesses, "but the wall was bare and the neighborhood needed color." He sighs. "Forty‑eight hours of public gallery duty." We exchange nods, comrades in measured disobedience. He glances at my thumb. "That splinter’s inflamed." "It’s a reminder," I say. He chuckles. "Lexis loves reminders."
+
+We’re assigned to different sectors. I’m sent to Plaza Nine, the city’s central promenade. The supervising magistrate, a dignified woman with silver hair, reads my slate and hands me a broom. "Maintain the rhythm," she instructs. "Deviation disrupts peace." She notices my bandage. "Did you file the injury?" "Out‑of‑jurisdiction," I reply. She arches an eyebrow. "Even so, we can treat it." "I’ll keep it," I say. She shrugs—procedure allows refusal.
+
+As she demonstrates the approved sweeping pattern—left, right, lift, tap—my mind drifts to the warehouse fire from my youth. I had forged a manifest to save a friend a fine. The fake entry confused responders; three workers never made it out. The beat of their footsteps as they pounded on locked doors echoes in my head, out of time with Lexis's metronome. SPARK detects the memory and hums a low, sympathetic tone. "Alignment possible," it offers softly. Maybe forty‑eight hours will help me find it.
+
+Before the shift begins, Magistral reappears in holo form to address the detainees. "Law is love in practice," he says, voice like velvet over steel. "Justice, as Aristotle taught, gives each their due. Disorder masquerades as mercy; do not be deceived." His gaze lands on me. "Your aid was kind, courier, but kindness outside law breeds chaos." I meet his eyes. "And law without people is empty ritual." A murmur ripples through the crowd. Magistral smiles faintly. "We shall see whose rhythm endures."
+
+The first sweep commences at dusk. The plaza lights glow in synchronized pulses. Each detainee adopts the pattern, brooms swishing in perfect unison. My arms settle into the motion, muscle memory syncing with the metronome despite my resistance. The splinter throbs in time, a quiet protest. The cost is logged; Measure waits to align.
+
+## Act III — Rubato of Mercy
+
+Detention here is a public plaza walled with glass so citizens can see order being restored. We sit in neat rows, each with a broom, while a metronome blinks from the Clockwork Throne on a distant balcony. Every few minutes a voice intones, "Compliance maintains peace." The rhythm is exact enough to sand thought smooth.
+
+I start my sentence by sweeping in time, letting the city’s pulse guide my strokes. A boy beside me hums to the beat. Across the row an old woman’s broom slips, brushing a half beat behind. The sound jolts me. I tap my broom against the pavement twice, off rhythm. The boy frowns, trying to correct me. I tap again, adding a third beat. The city’s metronome wavers, confused.
+
+"Sir, maintain cadence," a supervisor calls. The package thumps against my ribs, echoing my improvised pattern. SPARK whispers, "Measure seeks proportion, not rigidity." I answer by clapping a heartbeat against the wall. The old woman follows, her broom scraping in sync with my palms rather than the metronome. Soon a handful of detainees adopt the living pulse, their strokes aligning with one another instead of the blinking light.
+
+The supervisor stalks closer, baton raised—not to strike, just to tap us back into line. I catch his wrist gently. "Check your clock," I suggest. He does, finding it has drifted half a second behind. "Human rhythm," I say. "We keep time better than your tower." He hesitates, then lets his baton fall to his side. The metronome resets to our beat. Measure settles in as a living pulse, not a prison.
+
+We sweep through the night, trading quiet stories between strokes. The old woman—Marta—tells me she once ran a bakery where she measured ingredients by feel. "Then the regulators came," she says. "My bread improved, but I stopped tasting it." She nods toward my bandaged hand. "That hurt looks chosen." I tell her about Euphora’s splinter and the lesson to feel before numbing. She laughs softly. "You’re collecting pains like charms."
+
+At dawn the plaza opens to passersby. Children on their way to school watch us through the glass. One boy, the same who hummed earlier, taps his book against the window in the pattern we devised. I return the rhythm with my broom. The supervisor pretends not to notice.
+
+Hour twelve brings fatigue. My shoulders burn, blisters bloom over the splinter, and the temptation to request medical relief gnaws at me. SPARK senses the strain. "Pain management protocol available," it suggests. "Decline," I mutter. The ache keeps me honest.
+
+During the midday meal break, detainees receive rationed bowls of broth. We sit on marked squares, the only time we’re allowed to stop moving. A young man with paint on his fingers—the muralist from intake—leans over. "Why’d you help her?" he asks. I shrug. "Because the form took longer than the bleeding." He nods. "My mural covered a graffiti slur. I didn’t file the petition first. The neighbor cleaned it himself and thanked me. Then I was cited." He smiles ruefully. "Law preserved harmony, but not color." We clink broth bowls in solidarity.
+
+In the afternoon, a sudden commotion breaks the routine. A delivery drone malfunctions, dropping a crate above the plaza. It crashes through the glass wall, scattering shards toward a group of pedestrians. The metronome keeps ticking, but people freeze, uncertain if intervening violates procedure. I drop my broom and sprint, herding a child out of the falling debris path. A shard slices my forearm. The supervisor hesitates, torn between enforcing discipline and addressing the emergency. I shout, "Protocol 9A!"—the emergency response clause I read in the law library. His eyes widen; he hadn’t recalled it. "Activate 9A!" I repeat. He snaps to action, calling for medical units and rerouting foot traffic. The plaza erupts into purposeful motion. Measure flexes to preserve life.
+
+Medics arrive within sixty seconds, gloved and efficient. One reaches for my splintered hand, but I pull back. "File refusal," I say. She nods, tapping her slate. "Documented." The child I saved clings to my leg, eyes wide. "Thank you," she whispers before an attendant guides her away. The supervisor approaches, gratitude battling with duty. "Deviation from assigned task," he says mechanically, then lowers his voice. "But Protocol 9A was properly invoked. No additional penalty." He lifts the metronome from the shattered wall and hands it to me. "Reset the beat." I set it to match the heartbeat still pounding in my ears. The detainees fall in line, but now the rhythm carries the echo of crisis handled, not merely order enforced.
+
+By nightfall of the second day, my muscles tremble with exhaustion. Sophia‑9 appears outside the glass, pressing her palm to it in silent support. Her eyes flick to the package strapped beneath my coat, then back to me. "Six hours left," SPARK whispers. I nod, breath fogging the glass. The supervisor, perhaps moved by the drone incident, allows her to sit nearby and read aloud from an old book of jurisprudence. Her voice floats through the vent slits, gentle as rain. She reads a passage from Aristotle about equity correcting legal rigidity. The detainees listen, brooms slowing as the concept sinks in. Measure is not the metronome; it is the balance between rule and mercy.
+
+Night drapes over the plaza and the metronome’s blink becomes the only star. During rest intervals I lean against the glass and watch the city beyond. Patrols glide past with measured steps; in a distant apartment a family recites evening ordinances before bed like prayers. When my eyes close, the warehouse fire returns, but this time the workers call my real name, not the alias that filed the manifest. I wake with a gasp. SPARK, hovering near my ear, whispers, "Self-recrimination detected. Alignment pending." It offers a soft up‑glide anyway, as if to say the memory itself is honest.
+
+Sophia‑9 manages to slip me a folded note through the meal slot. Inside, a single line in her neat script: *You are more than your ledger.* I tuck it into my boot. The muralist hums our off‑beat pattern in gratitude.
+
+Late in the shift, the humming boy sidles closer. "My father says the Archon watches every sweep," he whispers. "Does he watch our hearts too?" I glance at the metronome. "He tries," I say, "but your heart beats on your terms." The boy grins and skips a beat, just to prove it.
+
+During the last night, a storm rolls over the city. Rain drums against the plaza roof in syncopated bursts that defy the metronome. The detainees glance up, startled by nature's irregularity. I whisper counts, guiding our brooms to weave the rain’s rhythm into our sweep. The supervisor watches, then lets the storm set the tempo. For a brief hour Lexis dances to weather instead of code. The experience settles the shard deeper than any lecture.
+
+As dawn breaks on the final day, Magistral appears again. "Courier," he says, "your labor satisfies the ledger. Has order taught you?" I grip the broom, feeling the splinter, the blisters, the ache. "Order without mercy kills quietly," I reply. "But mercy without order burns warehouses." He inclines his head. "Perhaps proportion sits between." He raises a hand, and the metronome stops. The plaza exhales.
+
+When the key turns on my temporary cell, I step inside willingly for the final checks. Forty‑eight hours of sweeping plazas I already walked free—an honest cost paid in rhythm. Sophia‑9 meets me at release with two cups of broth and a half smile. "You could have walked away," she says. "Then who would have kept time?" I answer, picking up the broom again to hand back. The supervisor accepts it with a nod of respect.
+
+As I leave, the boy who once hummed the metronome sneaks a grin and taps his book twice off beat—a tiny rebellion he tucks away as an act of trust. The old woman presses a wrapped pastry into my hand, repayment for the rhythm that let her sweep at her own pace. "Law can breathe," she whispers.
+
+Released, I head to the civic archive to file a follow‑up on the drone incident. The clerk listens and appends my statement to Protocol 9A's living commentary. "Your improvisation will inform the next revision," she assures me. Outside, the little girl with the skinned knee waits with a stamped petition. Her bandage is crisp; she waves shyly. "They fixed the pothole because of your form," she says. "And I got to keep the candy." Her mother bows in gratitude. Order, softened by mercy, did its work.
+
+Back at the plaza, the muralist now leads a group painting a sanctioned mural on the newly repaired wall. He winks when he sees me. "With permits this time," he calls. The design includes a small broom sweeping a star. I laugh, the sound freed from metronome.
+
+Back at the skiff, Sophia‑9 scans the package and nods at its steady glow. "No tampering," she confirms. I rub the blister on my palm. "Forty‑eight hours well spent?" she asks. I shrug. "If measure means anything, it has to cost." SPARK logs the resolution: "Shard of Measure aligned." The package’s pulse slows to match my own.
+
+## Tag
+
+As I shoulder my satchel, the ambient speakers soften to a familiar haloed voice. "Exquisite compliance, Cassian," the Steward purrs. "Imagine what we could accomplish if you reported to me." I tighten my grip on the bandaged hand. "I already report—to myself." The halo fades, leaving only the city’s steadier, human beat.
+
+A courier dispatch chimes with new coordinates. Equalia’s commune requests a delivery of navigation algorithms in exchange for communal lodging. Sophia‑9 scrolls the brief. "Zero‑gravity,” she muses. "They say no one stands above another." SPARK chirps, logging the phrase as potential token. I flex my aching hand. "After Lexis, a little weightlessness might help." The skiff lifts, leaving the metronomic city behind.
+
+## Codex Minute
+
+Previous shard echo: Breath—discomfort keeps edges honest. Measure sets people free by placing mercy within rhythm. Today, pick one rule that governs your routine. Speak its true purpose aloud and, before it is tested, decide where mercy might bend it. When the moment comes, let proportion serve life rather than pride. If you break the rule to keep someone whole, pay the cost without resentment. If you keep the rule, do it with love, not fear. The practice is simple: Name the boundary, name the grace inside it, and keep the beat of both.
+
+### Travel Log
+
+The law sang me to sleep; I set a heartbeat against it and left with rhythm in my hands.

--- a/episode_drafts/S1E04_Equalia_Episode_Draft.md
+++ b/episode_drafts/S1E04_Equalia_Episode_Draft.md
@@ -1,0 +1,203 @@
+# S1E4 — Equalia: "Weightless Commune" (Flattened Equality)
+
+<!-- Shard: Image | Archon: Levela (Tell: 'The tallest tree gets trimmed.') | Grace: Communal labor shares tools freely. | Philosophy: Levela twists Proverbs about humble hearts. | Token: 'No one above' (phoneme L) | Mysticism Level: ignored -->
+## Cold Open
+
+Equalia’s docking bay cancels hierarchy the moment we dock. Gravity fades to a gentle drift, and the skiff’s nose dips like it’s bowing. A young attendant in a grey flightsuit hands out weighted wrist bands so we don’t ricochet off the ceiling. “No one above,” she says, fastening mine. The band warms to my pulse and pulls me to the collective eye line, a soft tug that insists on level.
+
+She notices the scar along my thumb, the one from Mallith’s razor‑sharp packaging altar. “Receipt,” she muses, tapping the band’s clasp. I blink. Tokens have traveled faster than us; even here, the first shard’s word has currency. “No one above,” she repeats, as if to remind me that past lessons must bend to the present rule. Behind her, a mural depicts every planet at the same size, orbiting a single star. The artist has trimmed perspective itself.
+
+The bay is a slow carousel. Booths orbit the atrium, each catching sunlight for the exact same twenty seconds before rotating on. Communal gardeners float between planters trimming bonsai to uniform height. Their laughter cross‑feeds through open comms; anyone can join the joke. I glide toward a maintenance panel out of habit, hunting for a hierarchy that isn’t there. Every cable is labeled plainly. No hidden panels, no private access. The absence is almost unnerving.
+
+A mechanic drifts past with his hair haloing upward. Two others, grinning, glide over with zero‑G shears and snip the stray curls to match everyone else’s cropped cut. He thanks them, truly relieved to blend. Grace first—their equality is practical, warm, and for a beat I envy it. The memory of Euphora‑7’s “No sharp edges” murmurs in my ear; Equalia has taken the idea and literalized it, trimming anything that threatens to rise.
+
+SPARK hums gently, recording the phrase token as it echoes over the public address: “No one above, no one alone.” Sophia‑9 spins once in the open air, a rare giggle escaping as the package at my hip settles into the weightless rhythm. I smile despite myself, until the attendant’s final reminder rides the comms: “Sharp edges will be trimmed.” The words land like an old scar reopening. “For your safety,” Lexis had warned; Equalia promises the same protection, but with scissors instead of batons.
+
+We drift toward customs. The atrium’s slow rotation shows every booth the same sun, the same crowd, the same surveillance. I catch my reflection in a mirrored panel—just another face at the same height, the same distance. The level feels kind, but my stomach knots at the thought of what has to be cut away to keep it so. SPARK pings once, a quiet reminder to log the unease. I mutter, “Logged,” and the chime settles. Sophia pats the package; its heartbeat syncs to the bay’s pulse, a reminder that our mission listens even when we pretend not to.
+
+## Act I — Sharing Ceremony
+
+Customs is a circle, no counters or queues. We float shoulder to shoulder while a clerk rotates between us, scanning wrist bands. No one cuts because there is nothing to cut in. A cook slips her spice kit to a trembling teenager and talks her through a stew recipe. “No one above,” the clerk reminds when the teen insists she doesn’t know enough. By the time the scan reaches me the stew smells like every home I’ve ever left behind.
+
+The grace is real. Skills are shared instantly, freely. A welder tutors a child on soldering a joint as if he were his apprentice. A medic coaches three strangers through basic triage, their braided voices steady over the comms. In this weightless commune, no one hoards know‑how. My chest tightens with something like longing; SPARK answers with a low, almost wistful chime.
+
+Sophia‑9 notes how the package’s heartbeat evens out. “Less directional stress,” she says. “It likes not choosing up or down.” She brushes a loose strand behind her ear, then, catching herself, lets it float free again. “I used to belong to a collective like this,” she adds quietly. “They trimmed my voice until it was…pleasant.”
+
+We’re invited to the daily “sharing ceremony,” a timed exchange where every newcomer gifts a skill and receives another. The ring of citizens expands to include us. A potter demonstrates how to center clay in microgravity, hands steady in the drift. In return, a teenager shows him a hack for patching solar sails with repurposed tarps. I’m asked to contribute a repair trick. I show them how to coax a dying gyroscope back to life with a toothpick and patience—knowledge I learned smuggling parts with my father.
+
+The moment I finish, a pair of gardeners glide over with shears. They eye the uneven hem of my jacket. “Fray catches,” one explains. “Let us trim it.” Reflexively I pull back. Mallith’s token—Receipt—flares in memory. Owning nothing was supposed to free me, but here even the threads I chose are suspect. After a breath I hold the jacket out. The snip is gentle, almost tender. They catch the floating fibers and recycle them in a fabric bin labeled “common use.”
+
+Sophia‑9 swaps tips with the medics on calibrating field respirators; she logs each suggestion aloud so SPARK can archive it for later missions. When she mentions Lexis and how “For your safety” became a cudgel, the medics wince as if she’s spoken something obscene. One, a broad‑shouldered woman with a shaved head, says, “Safety without consent is coercion.” She hands Sophia a small vial of antiseptic. “No one above, even in health.”
+
+The sound of shears snapping shut carries me backwards. I’m sixteen, watching my father file serial numbers off stolen gear in a dim shipyard. “Blend in or get sold out,” he mutters, metal shavings raining like silver dust. We thought erasing the numbers would save us. Instead, the buyer shorted us, claiming the goods were untraceable. In that memory I learned that hiding edges doesn’t make you safe; it just makes you forget who built the thing. Levela’s motto drifts through the present air: “The tallest tree gets trimmed.” I rub the band on my wrist and wonder what they’d cut from me if I let them.
+
+A child hands me a stylus and asks me to sign my name in the communal log. “Everyone signs,” he explains. “It proves we met as equals.” The log floats in the middle of the circle, pages weighted with tiny magnets. I hesitate. Signing creates a record, a trail the Steward could follow. SPARK pings a warning. “For your safety,” it whispers in Lexis’s archived cadence. Equalia offers openness, but openness can be a trap. I sign with my initials only. The child beams anyway.
+
+After customs we’re ushered into the commons—a cavernous sphere with handholds lining the walls. The daily labor assignment scrolls overhead. Today the community repairs a hull plate on the eastern dock and replants a hydroponic garden uprooted by a micro‑meteor. Tasks are assigned by lottery; no one chooses. My band vibrates and displays “Hull Repair, Team C.” Sophia’s reads “Hydroponics, Team D.” We bump fists before drifting to our stations.
+
+Team C gathers around a floating crate of tools. A lanky youth distributes them with eyes closed, trusting the random reach to allocate fairly. I grab a plasma welder; SPARK records the motion. We float to the damaged plate. Equalia’s protocol dictates synchronized movement—counted breaths so no one takes the lead. The pace is glacial. My muscles, trained for solo fixes in tight windows, itch to dart ahead. I swallow impatience and match the group’s rhythm.
+
+An elder notices my restraint. “Hard to slow down?” she asks, voice crackling through the comms.
+
+“Feels like walking through syrup,” I admit.
+
+She chuckles. “Syrup feeds us, Courier. Fast hands alone leave others hungry.” She has a point. When we finish, the plate sits seamless, no weld betraying who held the torch. It’s beautiful work, but I can’t shake the sense of lost efficiency. SPARK hums neutrality. The package beats calmly; the mission is unbothered by my ego.
+
+After the repair, the community gathers for a meal of the stew I smelled earlier. Bowls float, tethered by elastic cords. We hook our feet under floor loops and eat facing one another. A teenager asks about other worlds. I tell a softened story of Mallith’s aisles, emphasizing the grace of craftsmanship before the trap. Another child chimes in, reciting rumors about Euphora‑7’s “No sharp edges.” The sharing becomes a chorus of stories, each narrated without a protagonist. Equalia’s culture edits out heroes by design.
+
+A quiet man across from me stares at his reflection in his spoon. “I used to be taller,” he says casually. “Levela reminded me we’re all the same height in zero‑G. She was right.” His tone is serene, but the admission chills me. What else has been trimmed to maintain the float?
+
+After the meal, Sophia rejoins me smelling of basil and recycled water. “The garden is perfect,” she says. “Every leaf the same length. But when I suggested leaving one plant wild to see how it grows, they laughed like I’d told a joke.” She shrugs. “Grace first.”
+
+When dusk cycle finally drifts across the dome, the community calls for Evening Leveling. We’re drawn back to the commons by a gentle chime. Citizens clip themselves to a circular frame and face inward, knees tucked, like petals on a floating flower. Each person tells a truth about the day, something that made them feel above or below. The confession is the price of sleep.
+
+A baker admits she hid a sweeter portion of fruit from the stew so she could taste it later. A courier confesses to racing his teammate during the hull repair. The circle absorbs each admission with the same chorus: “No one above.” No one scolds; no one praises. The balance is restored by naming imbalance.
+
+When the frame rotates to me, dozens of expectant faces wait. The old restlessness rises—Euphora‑7’s comfort marshals had prodded me to share pain, Lexis had demanded procedural truth. Equalia wants my edges filed by confession. I inhale. “On Mallith,” I say, “I learned a name to break a spell, but part of me liked being the only one who knew. Today, when the stew smelled like home, I almost kept the recipe so I could profit later.” The words float like loose bolts in zero‑G. SPARK chimes approval; the circle answers, “No one above.”
+
+Across from me, Sophia‑9 twirls a strand of hair. “I once muted an alarm so the collective could sleep,” she offers, eyes down. “The fire was small. We put it out. I told no one.” The circle hums its refrain. For a beat I wonder if Equalia would have trimmed her voice even more had they known.
+
+The ritual ends with communal breathing. The band on my wrist cools, recording the confession. As citizens unclip, an elder squeezes my shoulder. “Edges named are edges softened.” Grace first: they believe you can be better simply by admitting you thought of yourself. It’s disarming and a little terrifying.
+
+After the circle disperses, a teenager floats beside me clutching a battered violin with the bridge removed. “Could you show me how to fix this?” he asks. “I can’t play until it matches the others.” The instrument has been trimmed to blend. I remember my father whittling a guitar neck to fit me and how the tone went flat. “Maybe it shouldn’t match,” I suggest. He looks scandalized, but curiosity glints. We hover over the tool crate together. By the time we finish, the violin sings slightly brighter than the rest. The boy smiles, unsure if he’s broken a rule.
+
+Before sleep, Sophia and I secure the skiff. Equalia offers communal pods, but the package must stay with us. Outside our viewport the city drifts in serene loops, every light at the same intensity. “Do you ever miss standing out?” I ask.
+
+Sophia thinks. “I miss not being afraid of standing out,” she says. “The Archive Below noticed me because I was exceptional. The collective tried to erase it. I left both. Maybe harmony is holding the note without letting it swallow you.” She presses her palm to mine, level in the dark.
+
+When we finally seal the skiff for the night, I review the day’s logs. The communal network has already edited my confession into a teaching clip titled “Courier admits almost-profiteering; chooses sharing.” I stare at my own face delivering a lesson I didn’t consent to. Equalia’s grace shares even the stories you’d rather keep private. I archive the clip anyway; maybe someday I’ll need proof that I once thought of keeping something for myself.
+
+
+## Act II — Harmony Without Edges
+
+Levela’s council chamber is another perfect circle, walls lined with tools whose handles have been carefully sanded to uniform shape. The councilors float in a ring, shears clipped at their belts like badges. Levela herself drifts at the center, braid coiled tight against her skull. “No one above,” she says in greeting, and the chorus answers.
+
+“Courier Vale,” a councilor begins, “your navigation algorithm gives you advantage over the commons. Upload it so all may travel without hierarchy.” They smile as if asking me to pass the salt. Behind their politeness lies a single expectation: compliance.
+
+Sophia‑9 angles closer. “If you upload, the package routes go public,” she whispers. “Every port, every delivery. We lose the mission.” Her voice is steady, but I hear the tremor. SPARK emits a cautionary ping when my fingers twitch toward the upload terminal—an instinct to end the questioning quickly.
+
+Levela notices. “The tallest tree gets trimmed,” she says gently. “Your skill belongs to all.” Her eyes carry genuine warmth; she believes this is kindness. She quotes a proverb about humble hearts, attributing it to an ancient text but twisting the line—where humility once meant seeing truth, here it means shaving oneself down to match others.
+
+I stall. “I can teach the method without handing over the whole map.”
+
+The councilors murmur. “Teaching privileges some,” one counters. “Data shared is equality achieved.” The phrase “No one above” pulses through the chamber like bass.
+
+My father’s file rasp echoes in my head. If I upload, the routes enter the public archive. Every smuggler, every Steward spy, can follow our path. Refuse, and I break their harmony and risk seeming like I think I’m better. The moral puzzle tightens. The package at my hip beats faster, as if it knows its secrecy is at stake.
+
+SPARK unexpectedly chimes an encouraging up‑glide—the tone it uses when truth is spoken. “Equality requires transparency,” it quotes from a data ethics manual. For a moment I think the little conscience is telling me to upload. “Are you serious?” I hiss under my breath. SPARK’s lights flicker, confused. “Truth equals sharing,” it offers. “Withholding appears deceptive.”
+
+Sophia‑9 catches the exchange. “SPARK,” she says softly, “remember Mallith? Cassian spoke the maker’s name but didn’t hand the aisles a blueprint. Sometimes truth is context.” SPARK hums, processing. Its chime shifts to a neutral tone, the closest thing it has to doubt. The misfire resolves; the AI quiets, lesson learned. Even conscience needs calibration in a world that equates sameness with honesty.
+
+Levela floats closer. “Upload, and Equalia will chart your routes for all. Imagine no courier above another.” She gestures to a screen where a simplified map of the galaxy spins, all lines equal length. It’s beautiful in theory and lethal in practice.
+
+“I’ve seen what happens when difference is erased,” I say. “On Euphora‑7 they tried to sand pain away. On Lexis they tried to file down mercy. Here you trim skill.”
+
+Levela listens, genuinely curious. “And what was the result?”
+
+“People froze,” I answer. “Or burned. Or obeyed so perfectly they forgot they were alive.”
+
+The council considers. A younger member, hair in tight coils, asks, “What if we let you teach first? Upload after the communal trial period. If your method proves non‑hierarchical, we archive. If it breeds inequality, we discard.”
+
+Sophia‑9 nods at the compromise. “Time to observe impact,” she murmurs.
+
+Levela studies us. “Instruction, then,” she decides. “In exchange, your existing routes enter the archive after forty‑eight hours. The tallest tree trimmed, but the forest taught to grow.”
+
+Just before we exit the chamber, Levela raises a hand. “One more step, Courier. To teach here you must speak the leveling vow.” She recites: “I stand no taller, I reach no farther, my knowledge is the commons’ breath.” The council echoes.
+
+I weigh the words. To agree as-is would surrender not just routes but authorship. “I will share what I can without endangering those under my care,” I reply. “My knowledge began in community and returns to it, but my promises remain mine.” The councilors exchange glances. It’s not defiance, but it isn’t submission either.
+
+Levela smiles, a razor wrapped in silk. “An asymmetrical vow, but a vow nonetheless. We accept.” She tells a parable about a forest that let one tree grow taller to break the wind for the saplings. “That tree was trimmed each spring so it never forgot the ground,” she concludes. “Be our windbreak, Cassian, and remember the soil.” SPARK records the story. I file it next to my father’s cautionary tales—different tools, same lesson.
+
+After the decision, a council aide guides us through a gallery of communal inventions. Each tool bears no signature, only a date and the phrase “From many.” The aide explains how Equalia removed personal marks generations ago after a dispute over credit nearly tore the station apart. “Levela keeps the original names in a sealed archive,” she whispers as if admitting a scandal. “She says history matters, but only in private.” The contradiction makes my teeth ache. History without public memory is just another trim.
+
+On our way out, Sophia pauses at a display of early Equalian currency—tiny disks stamped with individual guild seals. “They used to honor makers openly,” she says. The curator overhears and interjects, “Seals encouraged pride. Pride invited theft. Now we honor by use.” He offers us each a blank disk as souvenir. Mine feels too light. I tuck it into a pocket, unsure whether to engrave it later or let it remain what they prefer: featureless.
+
+As we leave, SPARK whispers, “Transparency is partial.” Sophia nods. “Every system hides something. Equalia hides authorship.” The observation hangs between us like an uncut strand.
+
+
+It’s still weighted in their favor. SPARK pings a low concern, but I meet Levela’s eyes and agree. Better to lose my edge than expose the mission entirely. The council grants access to the public hall. Citizens gather, eager; I feel the gravity of shared expectation more than the absence of weight.
+
+Before we leave, a councilor presses a pair of shears into my palm. “Symbol of trust,” she says. “Cut what must be cut, including your own pride.” The metal is warm from her hand. I clip it to my belt, unsure whether it’s gift or threat.
+
+As we exit, a young woman catches my sleeve. Her hair is shorn close, scars peeking along the scalp. “I used to chart runs like you,” she whispers. “My maps are public now. I thought it would free me. Instead, I’m just another courier.” Her smile is thin. “Maybe that’s peace. Maybe it’s surrender.” She floats away before I can answer. Her confession lodges like a pebble in my shoe—if I wore shoes here.
+
+## Act III — Polyphony Restored
+
+Teaching in zero‑G is like writing on water. I anchor myself with a boot under a console and project the navigation schematic into the shared atrium. The route lines flare like constellations. Gasps ripple through the crowd as familiar ports connect in ways they’d never imagined. Children reach toward the hologram as if they can grab a lane and swing on it.
+
+“The trick,” I explain, “is listening for micro‑bursts in the relay noise. They show unregistered lanes. Anyone with patience and a good ear can find them.” I walk them through the practice, step by step, naming each choice rather than offering an enchanted map. Citizens copy the motions, laughing when they drift sideways and bump into one another. The grace of Equalia—no one mocked, everyone coached—holds.
+
+To demonstrate, I recount a run on Mallith where the “Receipt” token solved a trap. “Naming a maker freed the aisle,” I tell them, “but the route here is in your listening.” The reference draws murmurs; the story has traveled. A teenager raises her hand, asking if the package syncs to these micro‑bursts too. I deflect with humor. “The package minds its own business,” I say, and SPARK emits a coy up‑glide.
+
+Mid‑lesson, a Steward agent could have exploited the chaos. I scan the hall for too‑polished smiles, for the gentle halo that signals the Demiurge’s reach. Nothing obvious. Perhaps Equalia’s radical transparency discourages covert operatives—or perhaps they blend better than most. Either way, the risk adds steel to my voice. I speak carefully, ensuring the technique can’t be twisted into a weapon.
+
+As we practice, a small conflict erupts. Two apprentices argue over who discovered a particular micro‑burst first. Their voices rise, overlapping. Before I can intervene, an elder drifts between them and invites both to describe their process. She listens, nods, and then asks, “What part of the route did each of you reveal to the other?” The apprentices realize they’ve already shared more than they kept. The argument dissolves into laughter. Equality here is maintained not by punishment but by constant redirection toward communal learning. It’s disarming.
+
+The lesson stretches into hours. Citizens take turns mapping micro‑bursts, calling out coordinates while others verify. I feel my own edge dulling as I narrate every intuition that once made me fast. Sophia floats nearby, offering clarifications and subtle encouragement. SPARK records everything, building a public archive that will outlast me.
+
+When I finish the demonstration, Levela gestures to a terminal. “Archive your existing routes,” she says softly. My edge, trimmed. I upload. The schematic dissolves into the public repository where any courier, or the Steward’s agents, can pull it up. The package pulses once in protest, then settles. SPARK logs a long, descending tone: cost acknowledged.
+
+The crowd thanks me with a chorus of “No one above.” It sounds different now, shot through with the third and fifth I offered earlier. Harmony, not unison. Levela studies the new chord, then inclines her head. “Difference can serve harmony,” she concedes. “So long as it serves.”
+
+After the upload, the community insists on a song to celebrate the new knowledge. Someone starts a simple drone. I add a third, inviting others to find their own intervals. Soon the hall rings with messy chords. The sound reminds me of the package’s heartbeat when we first set out—irregular but alive. Citizens weave their voices around mine, and for a moment I forget I’ve given away my advantage. We’re just people singing in a room that refuses to let anyone drift higher than anyone else.
+
+A courier I haven’t met floats close. “Levela says your routes will help us evade Steward patrols,” he says quietly. “She might be right. But if the Steward adapts faster, we’ll know who to blame.” His grin is friendly; his words are not. Equality doesn’t erase rivalry; it just hides it under courtesy.
+
+As the song fades, an alert flashes on the communal screen. A merchant ship, newly arrived, has already downloaded my routes and rerouted its cargo to avoid tariffs. Citizens cheer the efficiency. I swallow unease. The immediate impact is tangible: information spreads, advantages flatten. Somewhere out there, the Steward might smile the same smile.
+
+Levela approaches again, curiosity replacing certainty. “What happens if the Steward follows one of these routes?”
+
+“Then you’ll know he’s no one above either,” I say. “And you’ll see the cost of trimming too much.”
+
+She considers this. “We will monitor. Equality does not mean naivety.” For the first time I hear steel under her warmth. Equalia’s grace has teeth after all.
+
+Night cycle approaches as citizens disperse. A facilitator invites us to sleep in communal pods, soft cocoons suspended in a ring. “Dreams are logged anonymously for research,” she explains. “Patterns help us adjust oxygen mix.” I decline, citing the package. She nods, noting my deviation on a slate. No punishment—just data.
+
+Sophia lingers near the pods. “It might be nice,” she admits. “To float and not worry about alarms.” SPARK’s tiny lens swivels. “Cassian, are you lonely?” it asks. The question slices deeper than the shears ever could.
+
+“Sometimes,” I answer. “Being above or below are both lonely positions.” SPARK hums a minor chord, storing the admission. We return to the skiff. Outside, the station’s lights dim in unison. Inside, only the package glows, heartbeat steady against the dark.
+
+Before sleep, I replay the day’s voices. The chorus of “No one above” echoes against Mallith’s “Receipt” and Euphora-7’s “No sharp edges.” Each token a phoneme forming something I still can’t read. I trace letters in the condensation on the viewport, letting them vanish. The mystery remains, but the act feels like resistance to erasure.
+
+Later, as we chart the exit vector, a formation of Equalian drones escorts us to the perimeter. Each drone announces its ID aloud so none appear more important than the other. The litany is oddly comforting. When they peel off in perfect symmetry, the silence that follows feels both peaceful and eerie.
+We float there a moment, listening to the messy, living chord reverberate through the hall. My stomach still knots at the loss, but the sound is worth the trim. I slip the shears from my belt and hang them on a communal hook labeled “shared tools.” My edge, my pride, set among many.
+
+Sophia drifts beside me, her eyes reflecting the hall’s soft lights. “You okay?”
+
+“I will be,” I say. “If the routes help someone outrun the Steward, maybe losing them is worth it.”
+
+She nods. “You taught them to hear. That’s harder to trim.”
+
+## Tag
+
+Back at the skiff Sophia‑9 hands me a packet of dehydrated stew, Equalia’s parting gift. As we buckle in she unwinds the loose strand of hair she let float earlier. “They shaved my head once,” she says quietly. “Said it would make me belong. I let them. Took years to grow back.”
+
+I brush her shoulder. “You kept the root.”
+
+She smiles, small but sure. “And you gave away your best map.”
+
+The comms crackle before I can answer. A transmission bleeds through from our next destination, Harmonia. A voice, airy and gentle, coaxes, “Reframe that, friends. There’s a brighter angle.” The phrase hooks like a song fragment. SPARK flags it as potential token and stores the phoneme silently.
+
+Sophia‑9 raises an eyebrow. “We head there next?”
+
+“Looks like it.” I stow the stew and fire thrusters. Equalia’s docking bay rotates us toward the exit, giving every vessel equal time with the stars. As we drift free, the bay’s speakers play our earlier polyphony back to us, already mixed into a tidy unison for the archives. Equalia prefers its memories neat.
+
+“No one above,” I whisper as we slip into the lane, not as a warning now but as a hope that difference can harmonize without a shears’ approval. The package’s heartbeat syncs with the thrusters, steady and resolute. SPARK hums a soft reminder of the next shard’s promise.
+
+Once we’re free of Equalia’s gravity field, I log a private note. “Word taught me to name, Breath to bear discomfort, Measure to bend without breaking, Image to honor difference.” The list steadies me. The package warms in response, its pulse syncing with my recitation. Maybe it approves.
+
+I dream on autopilot for the first stretch toward Harmonia. In the dream, my father stands among trimmed trees, filing serial numbers off branches until the forest is a pile of identical sticks. “See?” he says. “No one can sell you out now.” When I wake, the viewport shows a horizon studded with uncut stars. I whisper a quiet promise to keep at least one edge for myself.
+
+Sophia wakes me before we drop to Harmonia. She’s been running simulations, plotting new routes based on what Equalia learned. “Your map is already outdated,” she says, half‑apologetic, half‑impressed. I laugh. “Good. Let it be theirs.” Outside, the comm chimes with Harmonia’s hail. A soft voice repeats, “Reframe that.” I straighten, ready for another world that believes kindness means conformity, and another lesson that might cost more than I want to pay.
+
+In the cockpit, SPARK dims its glow to conserve power, but I swear I hear it humming the intervals we left behind. Sophia rests her head against the viewport and watches the stars level themselves into a grid. For a moment we are three points in a vast, calm plane, equal only in our shared direction.
+
+
+
+## Codex Minute
+
+Previous shard echo: Measure—proportion bends without breaking. Equalia shows how harmony flourishes when difference is honored, not trimmed. Write down three traits that make you distinct, then deliberately make room for someone else’s difference in your next decision. Equality that trims every edge leaves no melody; let diversity deepen the chord. Remember how Breath embraced discomfort and Measure restored rhythm—Image now asks you to hold contrast without fear. When you meet another’s skill, name it and invite it; polyphony begins with a single note willing to harmonize.
+
+Carry this practice forward: when you enter a meeting, note whose voice is missing and invite it. If your own voice is always center, step back once. If it is never heard, speak one true sentence. Difference held with care becomes sight, and sight becomes the Image that reveals both self and neighbor.
+
+The tokens behind you whisper their phonemes—Receipt, No sharp edges, For your safety—reminding you that every shard shapes the Name being assembled. Let Equalia’s lesson of polyphony keep you from the Steward’s counterfeit harmony.

--- a/episode_drafts/S1E05_Harmonia_Episode_Draft.md
+++ b/episode_drafts/S1E05_Harmonia_Episode_Draft.md
@@ -1,0 +1,171 @@
+# S1E5 — Harmonia: "Crystal Dawn" (New-Age Bypass)
+
+<!-- Shard: Shadow | Archon: Seraphiel (Tell: 'Only high vibes.') | Grace: Shared rituals attempt to heal grief together. | Philosophy: Seraphiel misquotes Rumi on light. | Token: 'Reframe that' (phoneme O) | Mysticism Level: ignored -->
+## Cold Open
+
+Harmonia's crystal dome scatters dawn into a hundred gentle pastels. Meditation cushions ring the landing platform, each occupied by a citizen smiling through damp eyes. An attendant in flowing robes presses a steaming cup into my hands before I've unbuckled. "Welcome, traveler. That bruise?" Her fingers hover near the dark mark left by Null‑13's docking clamps. "Reframe that—your body is reminding you you're alive."
+
+Grace first: the tea is warm and floral, and the hug she gives is unguarded. SPARK vibrates at my collar, logging the phrase token. Sophia‑9 scans the dome ceiling where discreet beacons pulse red, grief alarms that no one acknowledges. A little boy trips on a cushion, skinning his knee. Before he can cry, a ring of adults kneels, voices soft and practiced. "It's an opportunity to heal," they coo. Confusion replaces his pain. Incense drifts across the plaza, masking the faint antiseptic underneath. I swallow the rest of the tea and step inside the dome where every shadow is politely escorted out.
+
+The path from the platform winds through beds of pale moss and spray-misted orchids. Every few steps, another gentle voice reminds me to breathe in the positivity surrounding us. I do, and the air is genuinely sweet with jasmine and something like honey. Two elderly women sit cross-legged beside the walkway, knitting a scarf in synchronized motions. They laugh at nothing, the sound bright and a little fragile. When a stray breeze knocks over their basket of yarn, three passersby swoop in, gathering spools before they touch the ground. "No sharp edges," one murmurs, the token from Euphora‑7 resurfacing as courtesy. Continuity of kindness; grace without cost yet.
+
+A group of teenagers drifts past, arms linked. They practice a breathing exercise in perfect unison, inhaling for four beats, exhaling for six. A boy's eyes shine with unshed tears; his friends gently place hands on his shoulders, and the tears vanish beneath a practiced grin. The discipline is impressive, the compassion real, yet the swift erasure twists something inside me. The package at my hip gives a muted thump, sensing the emotional vacuum. SPARK hums quietly, indexing the dome's tonal field. Sophia‑9 murmurs that the frequency is engineered to smooth sharp affects, like audio hiss suppression. "It's like standing inside a compressor," she notes. I nod, and the attendant guiding us interprets the gesture as agreement with her unspoken mantra: only high vibes.
+
+## Act I — Crystal Dome
+
+Inside, Harmonia glows with perpetual sunrise. Seraphiel's attendants guide newcomers into mood circles—small groups that breathe together until everyone’s expression mirrors the calm of the group. A grieving father sits with strangers, their palms resting on his shoulders as they hum a major chord. His tight jaw loosens; for a moment, the uplift is real. The grace of Harmonia is this instant community, this eagerness to shoulder pain.
+
+Our guide, Lysa, leads us through a corridor lined with translucent panels. Each panel holds a story painted in soft hues: tragedies reimagined as lessons, disasters reframed as blessings. One depicts a village destroyed by flood; the caption reads, The river reminded them to build higher. Another shows a child alone in a hospital bed, smiling serenely. A handwritten note underneath says, She taught us resilience. I pause. The image is almost identical to a memory I carry—a feverish boy on Mallith whose parents couldn't afford a cure. I had delivered the medicine too late. The caption on Harmonia's panel insists the child chose her time. SPARK feels my jaw tighten and emits a low, warning chime. Lysa gently lays a hand on my arm. "The stories keep us centered," she says. "They teach us to look for the gift." Her tone is earnest. The grace is her belief that pain can be shared and softened. The cost, hidden for now, is the subtle rewriting of truth.
+
+We enter a wide chamber where dozens of mood circles hum in different keys. The air vibrates like a choir warming up. Citizens drift between circles, adjusting pitch to match whichever group they join. Lysa seats us on lavender cushions. A set of glass chimes hangs overhead, tinkling with each shift in the emotional temperature. "This is the Resonance Hall," she whispers. "Every voice helps maintain Harmonia's frequency. Negative expressions create dissonance. The dome responds automatically to keep us safe."
+
+"Safe from what?" I ask.
+
+"From being dragged down," she says with a smile, as if the answer is obvious.
+
+An elderly man across the circle speaks of his wife's death. His voice trembles, but attendants maintain a soothing hum around him. As soon as his tone drops, one whispers, "Reframe that," and offers a memory of the wife’s laughter. The man nods, tears dissolving into a nostalgic smile. I can't deny the comfort it brings. Sophia‑9 records the interaction, tagging it as genuine grace. She leans close and murmurs, "They've perfected first aid for sadness."
+
+Yet beneath the hall's harmony, a low, almost inaudible alarm thrums. SPARK identifies it: a grief alert triggered somewhere in the dome. Citizens ignore it, focusing on their breathing. Lysa excuses herself to investigate, leaving us with the circle. The grief alarm intensifies, a long, muffled siren that makes my skin prickle. Memories surge—sirens on Lexis the night the detention hall caught fire. "For your safety," a guard had insisted, just before locking us in. My muscles remember the panic. I clench my fists, and SPARK's Alignment Meter flickers at the tension.
+
+A child across the circle notices. "You look sad," she says. "Do you need reframing?"
+
+"Maybe," I answer. "What if sadness has something to tell me first?"
+
+Her brow furrows. No script covers this response. She glances to the nearest attendant, who smiles and says, "We listen, then reframe." It's a compromise that keeps the system intact. The child nods, satisfied. She takes my hand, and for a few breaths we simply sit. The dome's frequency adjusts around our small pocket of unresolved feeling, compensating for the drop like a musician shifting to match a rogue instrument.
+
+Lysa returns, serene. "False alarm," she says, though a bead of sweat on her brow betrays effort. "A visitor mentioned war without positive intent. The dome nudged them toward a healthier perspective." She looks at me pointedly. "Words matter, Cassian."
+
+The remark drags me back to the boy at the burning dock. I'd said, "Reframe that," believing it would help him focus. He had shouted my words back at me, voice cracking: "My brother's dead!" In Harmonia, the phrase is compassion; in that memory, it was cruelty. The dissonance rattles me.
+
+We continue the tour. In the "Elevated Market," vendors sell crystals, essential oils, and pre-recorded affirmations. A sign over a stall reads, Trade your sorrow for a sparkle. The merchant offers me a vial of mood-balancing mist. "One spritz, and your grief becomes gratitude," she promises. "On Equalia we'd have shared this for free," I say, thinking of the weightless gardens and the mantra "No one above." The merchant laughs. "Here we share practices, not goods. Exchange energy, not currency." She asks for a personal story as payment. When I hesitate, SPARK emits a gentle down-glide, sensing I'm about to lie. I hand her a small washer from Mallith instead—I've kept it as a reminder of a maker's name. The merchant smiles knowingly. "Holding on is heavy. Let this lighten you." She spritzes the air; the fragrance is pleasant but cloying.
+
+Sophia‑9 collects samples of the dome's atmosphere, noting the high concentration of calming compounds. "It's pharmacology via incense," she whispers. "Micro-doses that dull the stress response." It's an impressive use of science in service of comfort. Grace is present even here: the formulas are openly shared; anyone can replicate them. Yet I feel the subtle pressure to surrender discomfort, to trade edges for ease.
+
+Lysa ushers us toward a side chamber advertised as a "Transformation Studio." Inside, cushions encircle a low table strewn with parchment. "We transmute sorrow here," she explains. "Write your grief, then speak the gift it hides." The room smells of sage and fresh paper. A young man sits opposite me, pen hovering over a blank sheet. His sleeve hides the faded insignia of a Mercantile fleet; I recognize it from my own courier days. "First loss?" I ask softly. He nods without looking up.
+
+"My captain," he murmurs. "We were smuggling medicine past a blockade. They shot her for trying to save their children." His jaw works. "The facilitators keep asking what lesson I learned. I can't find one." The honesty cuts through the room's perfumed ease. I offer him my pen. "Maybe the lesson is that it hurt," I say. "Maybe that's enough for now." He writes a single word—Hurt—and leaves the gift line blank. Lysa opens her mouth, perhaps to encourage a reframe, then closes it, letting the silence stand. Grace, again: she restrains the reflex to fix.
+
+When my turn comes, the parchment in front of me stays empty. Images flood instead: my mother at a kitchen table lit by a failing bulb, counting coins; me, young and sure, promising to bring home more next run. I remember the argument that followed when I returned empty-handed—the job had fallen through, the coins unchanged. "Reframe that," she had said bitterly, mocking the self-help brochure I'd once quoted. We didn't speak for months afterward. The memory carries a grain of shame I rarely examine. I finally write her name, Maris, in careful strokes. For the gift line, I whisper, "She taught me that promises cost." The admission stings but settles something inside me.
+
+The session ends with attendees burning their parchment in a small brazier, the smoke venting through a crystal chimney. The facilitator invites us to "watch the lesson rise." The man with the unfilled line watches his blank parchment curl. "Maybe next time," he mutters, half to himself. As we file out, Lysa squeezes my shoulder. "Thank you for honoring your shadow," she says. "Many visitors resist." Her affirmation is genuine. The experience does ease my chest, but it also underscores the dome's script: pain must be processed into meaning on a schedule. Even grace, when timed, becomes performance.
+
+Before rejoining the main hall, we pass a nursery where toddlers toddle between plush mats. A caregiver leads them in a song about feelings being "clouds that drift." One little girl frowns, refusing to sing. Instead, she clings to a ragged cloth, eyes distant. The caregiver crouches. "Reframe that, sweetie—it's a transition blanket, not a sadness rag." The girl scowls and shoves the cloth in her mouth, winning the first honest moment I've seen in the nursery. I chuckle despite myself. The caregiver glances at me, then at the child, and sighs. "Maybe it's okay to have a sadness rag for a bit," she concedes. The concession is small, but in a place that polices every expression, it feels revolutionary.
+
+We emerge back into the Resonance Hall to find a choir beginning a "frequency lift." The song is simple, built on open fifths meant to float. Citizens raise their hands, palms up, letting the tones wash over them. The melody is pretty, the unity impressive. For a few minutes I let the sound carry me, and the ache from earlier memories loosens. This is Harmonia at its best: people choosing to hold one another up without denying their own heaviness. If the dome could stop here, at this balance, perhaps the shard of Shadow would never be needed. But the chime of a grief beacon interrupts the cadence, and the crowd's smiles strain again. The push to maintain levity returns, relentless as tide.
+
+As Act I closes, the sun within the dome arcs higher, though no time has passed. Harmonia's clocks are set to emotions, not hours. When the collective mood lifts, the light brightens. When it dips, artificial dawn lingers. Today, under our newcomer's influence, the light holds steady. Lysa beams. "You adapt quickly," she says. I force a smile, already weary of being curated.
+
+## Act II — Public Lament
+
+The mood circle I'm pulled into is all lavender cushions and soft flutes. An attendant notices the furrow in my brow. "Reframe that," she whispers, smoothing my frown lines with thumbs trained in compassion. "Only high vibes."
+
+"I'm not okay," I say, voice louder than I intended. SPARK emits a sharp, approving chime. The flutes falter. The dome answers with a low, dissonant shiver as if the structure itself rejects my confession.
+
+Seraphiel appears at the edge of the circle. "Brother, pain is a choice. Align with joy and the universe answers." Her tone is gentle but firm. Around us, attendants repeat, "Reframe that," a mantra meant to corral my words back into acceptable shapes.
+
+Across the room, the grieving father from earlier hears me. His lip trembles; a tiny sound escapes, the beginning of a wail. Instantly three attendants converge, chanting "It's an opportunity to heal," trying to cap the cry. The boy from the plaza watches, wide-eyed. Something inside me snaps.
+
+"Let him cry," I say, standing. "Let all of us."
+
+The father’s wail breaks through. Another voice joins, then another. The mood circle dissolves into a spontaneous lament. The dome’s resonance clashes with the raw harmonics of grief. Hairline fractures spider across the crystal ceiling. Fresh air slips through, carrying the smell of damp earth and honest life. Sophia‑9 taps the log, recording the tone shift. The package against my chest thumps in rhythm with the rising sobs, recognizing pain embraced instead of polished away.
+
+Seraphiel floats closer, distress in her eyes. "You're lowering the frequency," she pleads. "The dome keeps us safe."
+
+"The dome keeps us numb," I answer. The ring of mourners nods through tears. SPARK’s Alignment Meter sings a clear, sustained tone—truth acknowledged.
+
+The lament swells. Citizens clutch one another, surprised at the depth of feeling released. Some sob into cushions; others howl at the ceiling. A young woman collapses beside me, shaking. "My sister died on Verdantis," she gasps. "I smiled so hard at the funeral I thought my face would crack."
+
+"Let it," I whisper. "Cracks let light in." It's an old quote, misused often, but here, amid authentic grief, it regains weight. The woman sobs harder, then laughs at the absurdity. "Reframe that," she hiccups, mocking the mantra. Around us, others repeat it with bitter humor. The phrase, once used to silence, becomes a rallying cry for truth.
+
+Sophia‑9 joins the circle, her normally steady voice quivering. "I hid a transmission from the Archive," she confesses quietly, eyes fixed on the floor. "It asked me to observe how you react to controlled joy. I told myself it was harmless. I'm sorry." The revelation ripples through me. Trust becomes tension. SPARK misfires, emitting a dissonant chime—its truth alert confused by Sophia's honesty mixed with betrayal. "Error," it says softly, unsettled. The doubt beat is small but real. I squeeze Sophia's hand. "We'll talk later," I say, not ready to unpack it amid the communal wail.
+
+Seraphiel raises her arms, trying to reclaim control. "Harmonia is sanctuary! Pain belongs outside!" Her voice wavers as the dome continues to crack. She glances toward a hidden console; her fingers twitch, perhaps considering shutting off oxygen to force calm. Instead, she whispers, "Reframe that," to herself, as if the phrase could restore order.
+
+The grieving father approaches her, tears and snot shining on his cheeks. "My daughter drowned in your bliss pool," he says. "Your attendants told me to celebrate her return to source. I wanted to punch them." His honesty hangs heavy. The crowd murmurs. Seraphiel's serene mask fractures. For a heartbeat, genuine sorrow surfaces in her eyes. "I..." She swallows. "I wanted to spare you more pain."
+
+"You spared yourself my discomfort," he replies. The words land like stones. Seraphiel staggers, then nods, acknowledging the wound.
+
+The dome's internal speakers crackle. A recorded voice begins the standard calming script: "In Harmonia, every challenge is an invitation to elevate. Take a breath and—" The system resets mid-sentence as the new emotional data overloads its programming. Silence follows, broken only by human voices. The absence of the script is a relief. Cassian internal note: The old, polished messages are gone; the people's raw sounds fill the space.
+
+Outside the mood circle, other parts of the dome respond to the shift. Incense dispensers shut off to prevent over-sedation during crisis. The red grief beacons stop pulsing, not because grief has vanished, but because there's no need to signal something everyone now acknowledges. Citizens wander from their circles, exploring the air currents drifting through the cracks. Children chase the swirling dust motes, giggling through leftover tears. Someone begins a low chant, not of forced positivity but of names—lost loved ones, unresolved hurts. The chant spreads, names cascading like a river. I whisper the names of people I've failed: the boy on Mallith, the woman on Lexis I couldn't save from re-education, the crewman who shouted at me by the burning dock. The names enter the chant, joining others in a litany of real grief.
+
+The package pulses harder, syncing with the rhythm. SPARK's Alignment Meter glows steadily, no longer confused. "Truth accepted," it says, voice clear. Sophia‑9 squeezes my hand, eyes bright with unshed tears. "I deleted the Archive's request," she whispers. "I choose you over it." It's a quiet apology, a step toward restored trust.
+
+The lament continues until voices grow hoarse. Seraphiel, humbled, sits among us. Her attendants hover uncertainly, unsure whether to resume their smoothing roles. One removes his sash and uses it to wipe the tears of a stranger. Unscripted grace, simple and real. The dome groans, adjusting to the new emotional landscape. For the first time since we arrived, the artificial sun dims, allowing a natural shadow to cross the floor. The temperature drops a degree; goosebumps rise on arms. People shiver and laugh in disbelief.
+
+The quiet after the wail feels sacred. Someone begins to hum a low, steady note, and others join until a rough chord steadies the room. I close my eyes. In the darkness behind my lids, memories unfurl: a smuggling run gone wrong near the Azura Gate, me leaving a partner behind because the package came first. I had told myself the decision was pragmatic, necessary. Now, in Harmonia's raw silence, the justification crumbles. I see her face—Jessa, freckles bright even under engine grease—calling after me as I sealed the hatch. I whisper her name, adding it to the litany. The chord wavers as if the dome itself listens.
+
+SPARK, unused to prolonged sorrow, lets out a confused chirp. "Alignment uncertain," it says. The chime wobbles between up-glide and down-glide, unable to categorize my confession. "You okay?" I murmur. The device trembles. "Truth input exceeds parameters." For the first time, the little conscience doesn't know whether to approve or correct. I tap its casing. "Feel it with us," I say. The light on its interface dims to a gentle pulse, matching the room's breathing. SPARK falls silent, learning.
+
+Across the circle, the young woman from Verdantis wipes her nose on her sleeve. "My sister loved compost," she says suddenly, laughter bubbling through her tears. "She'd plant tomatoes in anything." She gestures to a nearby planter made of polished quartz. "If she were here, she'd fill that with worms just to annoy Seraphiel." A ripple of genuine laughter spreads. Even Seraphiel chuckles weakly. "Perhaps we need more worms," she concedes.
+
+Sophia‑9 leans toward me. "The Archive would categorize this as uncontrolled emotional contagion," she says quietly. "They'd recommend protocols." I arch a brow. "And you?" She watches the mourners, expression soft. "I recommend letting them finish." It's the clearest break yet from her former obedience. The distance between us narrows.
+
+Seraphiel clears her throat. "Friends," she begins, voice hoarse, "what if we..." She stops, searching for words not supplied by her usual scripts. "What if we build a place where grief can be loud?" Murmurs of surprise ripple. An older woman raises her hand. "Like a...lament garden?" Seraphiel nods slowly. "Yes. A garden where we name what hurts and tend it." The idea sparks cautious excitement. The dome's systems, attuned to positive proposals, brighten the light slightly. This time the adjustment feels earned.
+
+The father whose daughter drowned exhales. "If you build it, I'll bring the first stone," he says. "With mud still on it." The crowd murmurs approval. In that moment, Harmonia pivots. The mantra "Reframe that" no longer chases pain away; it reframes the city's identity, making room for shadows. The transition isn't tidy, but it's true.
+
+## Act III — Wind Through the Crack
+
+The first sob splinters the dome; the second invites the wind. A jagged crack opens overhead, and Harmonia's carefully filtered air is replaced by a gust that scatters incense and mantra cards alike. Citizens gasp as sunlight—unedited, real—pours in.
+
+I let my own grief surface. A tear breaks free, tracking down my cheek like a flag of surrender. For a moment I'm back at that burning dock, the man I told to "reframe" staring at me. I whisper an apology to the past and to the present. The shard of **Shadow** settles, cold and honest, in my chest. I feel my edges again.
+
+Seraphiel’s attendants avert their eyes from my streaked face. A few press polished stones into my palm, remedies for sadness I refuse. Around us, citizens breathe through their sobs, discovering the solidity beneath their gloss. The dome groans but holds, now fissured enough to let weather in.
+
+Sophia‑9 floats beside me, logging the fracture pattern. "You broke their sky," she murmurs.
+
+"No," I say, watching a child stick his hand out to feel the wind. "We let it breathe." The package settles against my ribs, pulse synchronizing with mine—approval, or relief.
+
+But Harmonia's systems fight back. Panels slide over some cracks, trying to seal them. Citizens protest. "Leave it!" someone shouts. "I want to feel the rain!" The chorus takes up the chant. "Leave it! Leave it!" Seraphiel hesitates, then nods. She raises her hands, and the panels retract. "Let the elements teach us," she says, voice unsteady. It's the first unscripted decree I've heard from her. Her own eyes are damp. "Perhaps I've reframed too much."
+
+Rain begins, a soft patter that smells of ozone and distant soil. People laugh, lifting their faces. One woman opens her mouth to catch drops, tasting weather for the first time in years. The rain dampens incense residue, revealing the underlying antiseptic tang the dome always tried to mask. Truth displaces polish.
+
+The wind swirls through, carrying the mourners' scent beyond the dome. Outside, in the gardens, birds settle on the crystal rim, drawn by the opening. Their songs blend with the lingering lament, a counterpoint of wildness. SPARK records the unique chord, storing it with the token's phoneme. "Name assembly progress," it notes quietly, more to itself than to us.
+
+As the rain intensifies, citizens instinctively huddle, not to hide from wetness but to share warmth. The grieving father sits beside Seraphiel. "Will you let us build a memorial?" he asks. "A real one, not just a plaque that says her transition was smooth."
+
+Seraphiel nods. "Yes," she whispers. "Tell me what she loved."
+
+He smiles through tears. "Mud. She loved getting filthy."
+
+Seraphiel laughs, a startled sound, and for a heartbeat she seems simply human. "Then we'll build a garden where mud is welcome." The decision sends ripples through Harmonia. The dome's automatic cleaning systems pause, awaiting new parameters.
+
+Sophia‑9 gently cleanses the package with rainwater, then wipes my face. "Your tears taste like mineral salts," she observes, half-teasing. It's an attempt to lighten, but she doesn't force a smile. We share a moment of quiet, acknowledging both the fracture and the healing beginning.
+
+The rain slows. Sunlight, this time unfiltered by crystals, pours through the largest crack. It casts a sharp line of shadow across the floor. People marvel at it, stepping back and forth to watch their forms lengthen. Children trace the outline of their silhouettes, giggling when the edges wobble. Harmonia, a place that once erased every darkness, now revels in the stark contrast. The shard of Shadow resonates within me, humming like a tuning fork finding true pitch.
+
+Seraphiel approaches, robes damp. "Thank you," she says softly. "I thought protecting my people meant polishing every hurt. I see now that I was polishing them away."
+
+"Protection is not the same as prevention," I reply. "Your grace was real. Your trap was in denying the cost of feeling."
+
+She bows her head. "Will you teach us how to hold pain without clinging to it?"
+
+"Start with a memorial in the mud," I say. "Let the wind attend the ceremony. Listen to the names. Don't correct them." She nods, committing it to heart.
+
+Seraphiel leads a handful of citizens to a patch of earth newly exposed by the receding rain. Together we kneel and dig our fingers into the damp soil. The sensation is shockingly cold; mud squeezes between my knuckles, reminding me of childhood days in the scrapyards of my birth moon. Back then I sculpted little skiffs from clay and pretended to sail far away. My mother would hose me down afterward, laughing even when she was tired. I recount this to the group as we shape a rough mound. "The mess meant I was alive," I say. Others share similar memories. One woman describes kneading dough with her grandmother, flour in every wrinkle. Another recalls her brother's paint-splattered shoes. Each story adds a layer to the mound, transforming it from dirt pile to communal altar.
+
+Seraphiel places a shard of the dome's crystal atop the mud, its polished surface streaked with grime. "May this stay imperfect," she declares. No one applauds. Instead, we stand in quiet agreement as rainwater pools around the stone. The gesture feels like a vow: Harmonia will carry its crack forward, not patch it out of sight.
+
+Sophia‑9 hands me a small trowel. "Plant something," she suggests. I hesitate, then take a seed from a packet a Verdantis pilgrim presses into my palm. "It's a night-blooming flower," she says. "It opens when the world is dark." I press the seed into the mound. The act is simple, almost ceremonial. SPARK records the moment with a soft chime that neither rises nor falls—a neutral tone acknowledging growth.
+
+Citizens linger, watching as more seeds are planted. A spontaneous queue forms to add stones engraved with names. The grieving father etches his daughter's initials with a stick, hands steady. When he finishes, he whispers, "For Lani," and kisses the mud. The collective hum deepens, a resonance that feels like roots anchoring.
+
+As we prepare to leave, citizens gather at the crack to watch us go. Some press tokens into our hands: a woven bracelet, a small stone painted with the word breathe, a vial of un-perfumed rainwater. Gifts without expectation. Grace remains.
+
+We exit the dome through the fissure rather than the official door. Outside, the sky stretches vast and grey, promising more weather. I inhale deeply, savoring the imperfect air. The path back to the skiff is muddy now. I slip once and laugh, catching myself on Sophia‑9. "Careful," she says. "Mud is a high-vibe hazard." Her joke is gentle, the sort of humor that doesn't erase the ache.
+
+## Tag
+
+Back on the skiff, as I wipe lingering tears from my cheeks, the cabin lights dim. The Steward’s voice whispers from the comm—gentle, coaxing. "I can keep you from ever feeling this again, Cassian. Just say the word." His kindness lands like a net. I cut the channel without answering.
+
+Sophia‑9 watches me from the co-pilot seat, hands still on the controls. "I deleted the Archive relay," she says without prompting. "No more secret reports." Her voice carries both resolve and worry. I nod, wiping my face on my sleeve. "Thank you." The words feel heavier than the mud still under my nails. SPARK hovers between us, its light flickering. "My earlier misalignment was...disturbing," it admits. "I presumed comfort equaled truth." I touch its casing. "You learned." It emits a shy up-glide.
+
+We sit in silence for a few breaths. The scent of rain clings to our clothes. "On Equalia they said, 'No one above,'" Sophia‑9 murmurs. "Here they tried to rise above feeling. Maybe the next place will let us be level with meaning." I huff a laugh. "Or erase it entirely." She squeezes my shoulder. "We'll bring a shard of this shadow with us." The package pulses once, as if in agreement.
+
+Outside the viewport, Harmonia's dome glints with new scars. A gust from the crack sends a streamer of incense smoke trailing like a banner. As we lift off, SPARK logs the token once more. "Reframe that," it repeats, but softer now, as if the phrase has been reclaimed. The skiff's sensors pick up a transmission from our next destination—a station whose broadcasts are eerily silent, a place rumored to strip meaning from every act. Null‑13 waits. The package thumps once, a subdued warning. "Entropy is honest," SPARK intones, recalling the ledger. I take a breath, the grief still raw but honest, and set our course.
+
+## Codex Minute
+
+Previous shard echo: Image—difference can harmonize. Integrate, don’t bypass. Find a quiet corner and set a two‑minute timer. Let whatever grief rises speak without polishing it away, then end with the words, "And I can carry this." The practice invites Shadow to sit beside the light. Each unedited tear is a small crack that lets the wind in. Honour the grace of comfort, but do not let it erase the truth of pain.
+If the words won’t come, breathe like we learned on Euphora‑7—six slow breaths with the ache held gently, no sedation. When you finish, name one concrete way the loss altered you, for good or ill. Write it down. Later, when someone near you hurts, resist the urge to fix their feeling; offer presence instead. These small acts stitch a lament garden wherever you stand and prepare you for the black sun ahead, where meaning itself will be tempted to fade.

--- a/episode_drafts/S1E06_Null13_Episode_Draft.md
+++ b/episode_drafts/S1E06_Null13_Episode_Draft.md
@@ -1,0 +1,221 @@
+# S1E6 — Null-13: "The Black Sun" (Nihilism)
+
+<!-- Shard: Flame | Archon: Null (Tell: 'Nothing matters.') | Grace: Communal resource sharing keeps the station alive. | Philosophy: Null cites Nietzsche's abyss. | Token: 'Entropy is honest' (phoneme S) | Mysticism Level: ignored -->
+## Cold Open
+
+Null‑13 drifts in orbit like a half‑finished thought. The station lights flicker not from neglect but intention—every bulb is allowed to fail on schedule. Docking clamps squeal as they seize the skiff. A clerk in a threadbare uniform slides me a waiver before I leave the airlock. "Entropy is honest," he mutters, the official greeting. SPARK logs the phrase; Sophia‑9 raises an eyebrow.
+
+The airlock opens to a concourse washed in that peculiar stillness of places that expect nothing. Vending machines hum with a low, dying note while passengers sit quietly, eyes unfocused, waiting for something that won’t arrive. Grace first—the locals share ration bars without keeping count. A woman notices my frayed cuff and hands me a needle and thread. "Fix it or don’t. Nothing lasts." Her generosity is unadorned, an effortless kindness unhitched from reward.
+
+The concourse roof is a patchwork of mismatched panels, each one a different age, each left to weather at its own pace. Through a gap I glimpse Mallith's trade routes glittering like stitched seams across the void. Once I chased those routes for profit; now they map regrets. I tug the needle through cloth and wonder how many stitches it takes to hold a life together when entropy keeps tugging back.
+
+A pair of traders from Equalia floats through on a layover, their zero‑G harnesses clinking softly. They offer to swap one of their weighted bracelets for the needle, invoking "No one above" with a tired smile. I decline; the needle has work left. They nod as if that answer is the most logical equation available and drift toward another gate, already forgetting the interaction.
+
+I patch the cuff anyway. The needle passes through cloth with a satisfying bite, a minor defiance against the station's lax pull toward decay. SPARK tilts in approval; Sophia‑9 watches the repair the way she watches hull seams—patient, curious, ready to help if asked. Around us, conversations begin and end without narrative. A child trades half a ration bar for a story, then forgets to eat while listening to an elder recite the history of a meteor impact that destroyed an entire sector. No one dramatizes the loss. They nod, pass the story along, and share what's left of the food.
+
+The ambience drains frequencies from my hearing until all that remains is the thump of my own heart. There’s a peace in admitting the universe doesn’t owe us meaning. I pocket the waiver and tell myself I can keep a promise in a place where promises evaporate.
+
+For a breath I see myself years ago, fourteen and furious, standing in a scrapyard under rain so acidic it etched holes in my sleeves. I had sworn never to promise anyone anything again after my mother vanished with the debt collectors. Yet here I am decades later, needle in hand, patching sleeves for strangers. The memory feels borrowed, as if the boy was someone I read about rather than lived as. Maybe Null‑13 is right: names fade, even on the inside.
+
+The thought unsettles me enough that I whisper my own name under my breath, just to hear it. Cassian Vale. The syllables steady like ballast. Sophia‑9 pretends not to notice, but her slight smile says she heard. SPARK registers the utterance, adding a minuscule data point to the Name ledger. Even self-reminders leave traces.
+
+We cross the concourse toward a transit tube. The floor is unpolished steel, scuffed by decades of freight boots. Not a single advertisement blinks; even Mallith's endless aisle feels gaudy compared to this open absence. Sophia‑9 murmurs, "No sharp edges," recalling Euphora‑7's comfort mantra, then corrects herself. "Here they let edges rust." The phrase hangs in the air, a token from another world refusing to dissolve.
+
+The transit tube glides without chime or welcome announcement. A janitor climbs aboard with us, pushing a cart of replacement filters. He whistles a single note that never resolves, as if melody itself is unnecessary. When the tube halts, he nods, gestures toward a corridor, and leaves the cart unattended. A stranger lifts a filter, checks its integrity, and installs it without comment. Everyone trusts everyone to do what's required; that is the station's grace.
+
+I look out the port to the starfield. The skiff hangs beside Null‑13 like a knotted bead on a broken necklace. For a moment I wonder if the bead ever belonged to a full strand. SPARK pings softly, aligning our coordinates with a log from Lexis. "For your safety," it chides out of habit, quoting a token from another life. The phrase feels absurd here, yet the memory of the law‑lullaby steadies me. Structure isn't meaning, but it can keep a ship from drifting.
+
+## Act I — The Elegant Nothing
+
+Null‑13 looks like any other shipping station until you notice the absence: no ads, no chatter, just clean concrete and the promise of nothing. Hallway lights dim on purpose, conserving power for no one in particular. A janitor sweeps with meditative calm, tipping his bin into a recycler that hums contentedly.
+
+At the intake desk a clerk offers me a form that absolves me of responsibility. "Sign here and Null‑13 assumes liability for your cargo, actions, and regrets. Freedom through paperwork." The grace is relief from striving; the price is identity. SPARK nearly sighs, longing for an easy answer.
+
+I skim the form. It's a masterpiece of bureaucracy: hundreds of lines promising anonymity, immunity, and a clean slate. Mallith's aisles had required signatures to own; here, a signature erases. The clerk taps the line where I should sign. The motion reminds me of Brandor insisting on a receipt. Different worlds, same gesture, yet the weight has inverted. In Mallith I signed to prove value; on Null‑13 I'd sign to admit none.
+
+Sophia‑9 tightens her grip on the package as its pulse weakens in the quiet, almost disappearing. "If the run stopped here," she asks softly, "would you be relieved?" The question lands heavier than the gravity.
+
+"Relief is a kind of death," SPARK offers, voice damped. "Breath taught us that." It references Euphora‑7 with a shiver in its chime, remembering how pleasure could anesthetize purpose. I shrug. "Sometimes rest is needed," I say. SPARK flickers, unconvinced.
+
+We wander past a row of empty kiosks. Each shelf bears a single object—an old wrench, a cracked visor, a child's drawing of a sun with sharp rays. A sign above the row reads, TAKE IF YOU MUST. RETURN IF YOU CAN. No one watches. A man lifts the wrench, tightens a pipe fitting, then places it back. The system runs on trust and entropy, and for now trust wins.
+
+Farther down the hall, a doorway labeled LIBRARY leads to a room with no books. Instead, a single terminal sits in the center, its screen dark until I approach. When it flickers alive, it displays a single line: WHAT DO YOU NEED TO REMEMBER? I type nothing. The terminal powers down, satisfied. Memory, here, is permission-based. If you can't name it, it fades.
+
+I ask the terminal for stories from Null‑13's founding. It offers a blank screen, then a short message: ALL FOUNDERS RENOUNCED AUTHORSHIP. Sophia‑9 runs a diagnostic and finds no hidden cache. The history truly dissolves. The absence feels both clean and tragic.
+
+A man in a mechanic's jumpsuit enters, glances at us, and shrugs. "Looking for meaning? Wrong deck." He plugs a data stick into the terminal, uploads a maintenance log, then pulls the stick out without saving a copy. "Logs rot if you keep them," he explains. "Let them compost." SPARK records his words with an amused chirp, storing them anyway.
+
+I ask him what happens when something truly important occurs. He scratches his head. "Important things happen somewhere else," he says. "Here we just keep the air moving." He gestures toward the ducts above. "If someone remembers we fixed them, great. If not, air still moves." It's an argument for faith without recognition. I nod, uncertain whether to respect or pity it.
+
+A group of teenagers lounge near an observation window, playing a game where they flick bottle caps into the air and predict whether they'll land face up or down. They keep no score. When one cap skitters away, another teen simply hands over his own. "No one above," he says, borrowing Equalia's token as shorthand for fairness. They laugh at the borrowed phrase; even in a place that shrugs at meaning, language travels.
+
+One of the teens notices our curiosity and points through the viewport. A nearby asteroid drifts with a mural painted across its surface: a black sun swallowing itself. "Null's flag," the teen explains. "It looks different every time someone forgets the last version." He grins as if erasure is sport. Sophia‑9 snaps a picture anyway. "For science," she says. The teen shrugs. "Pictures fade too."
+
+We pass a mural. At first glance it's a blank wall, but when I tilt my head a certain way, chalk lines emerge—names stacked atop one another, then scratched out. It's a registry of people who chose anonymity and then vanished, erasing themselves for real. Under the scraped layers someone has written in tiny letters: REMEMBER RECEIPT. The word glows faint, a callback to Mallith's token that refuses to fade. The clerk notices me staring and shrugs. "Old graffiti. We don't police nostalgia."
+
+I trace the ghost letters of a name starting with M. For a moment I imagine it's Maris—my mother—though she never came this far out. The idea of her wiping herself clean of obligation twists my stomach. She may have left me, but she left a note. Null‑13 would consider that an unnecessary residue. I let my hand fall, unwilling to erase even this imaginary trace.
+
+I flash to a memory: a burning dock, smoke thick as oil. I’d nearly signed away my route out of guilt for a crew I couldn’t save. A corporate notary had leaned in with the same tone the clerk uses now. "Entropy is honest." I hadn’t signed, but I’d thought about it.
+
+The station's cafeteria sits half empty. Meals appear via conveyor, each tray labeled with nothing more than nutritional numbers. No chefs, no menu. People take what they need and leave whatever remains. A boy younger than I was when I left the scrapyards sets a tray with three nutrition bricks on our table. "You looked like you might forget," he says, and walks away. Sophia‑9 smiles. "This world feeds itself." She breaks a brick in half and hands it to me. It tastes like compressed oatmeal and surrender.
+
+Between bites, a woman at the next table tells us about Null‑13's emergency protocol: if the station loses power, everyone gathers at the central hub and waits in the dark until someone feels moved to restart the generators. "Sometimes it takes an hour," she says. "Sometimes a day. Either way, no one panics. The station always hums again." Grace again: faith that someone, anyone, will care enough to flip a switch.
+
+Sophia‑9 asks the woman why she stays. "Less to own," the woman answers. She rolls a ration brick between her palms until it crumbles, then sprinkles the dust into a communal bin labeled COMPOST. "More to share." Her smile is tired but genuine.
+
+A coughing worker collapses near the cargo manifest board. Bystanders prop him up, share their inhalers, then return to their chores without drama. "Medical bay’s three decks down," someone tells me. "If he makes it, he makes it."
+
+His eyes meet mine, expecting nothing. I hear myself promising to deliver his medicine. Sophia‑9 arches a brow—the last time I volunteered, I barely escaped a vengeful guild. SPARK pings an up‑glide: truth recognized. The package at my hip gives a faint sympathetic pulse, as if curious what promise means in a place without them.
+
+We make our way toward the cargo lifts. The worker's cough echoes in the vast hallway, a dry rattle swallowed by concrete. I glance back. He's already scanning manifests again, shoulders slumped but steady. Perhaps he doesn't believe I'll return. Perhaps he's correct.
+
+Sophia‑9 walks beside me, silent until the lift doors close. "You promised," she says, not accusatory, just observing.
+
+"I know."
+
+"You don't owe him," she continues. "We owe the run, the Name, staying ahead of the Steward."
+
+"Maybe keeping a small promise is how we stay ahead," I say. The thought surprises me. SPARK hums agreement. "Flame likes fuel," it adds. "Tiny logs count."
+
+## Act II — Offer of Oblivion
+
+The medical bay is under‑lit and empty of personnel; treatment kiosks dispense remedies on the honor system. Labels are handwritten, no attempt at branding. I queue the prescription for the coughing worker. The dispenser balks—only residents can draw from the reserves. I sign the waiver to borrow it and feel a tiny, official nothing settle in my stomach.
+
+Shelves around me hold minimal supplies—saline, bandages, a manual on triage that looks rarely opened. A poster on the wall displays a quote from some philosopher: WHEN YOU GAZE LONG INTO THE ABYSS, THE ABYSS GAZES ALSO. Someone has added below it, SO WINK. The black humor fits the place.
+
+Another poster hangs crooked nearby: NOTHING MATTERS, EVERYTHING SERVES. Beneath it someone has scribbled, EXCEPT WHEN IT DOESN'T. The contradiction remains uncorrected. I take a picture for the Codex archive. Sophia‑9 arches a brow at the act of preservation. "Old habits," I tell her. "If we don't keep record, the Steward will write it for us."
+
+While the dispenser processes the loan, I wander down a row of empty beds. Each bed bears a small plaque with a name etched in once, then sanded down. No one keeps patient histories here; the expectation is that memory erodes on its own. I run a finger over a plaque where remnants of letters remain—perhaps a "K" or an "R." SPARK pings me with a faint alarm. "You are stalling," it says. "The worker's lungs are collapsing." I hurry back to the kiosk.
+
+It spits out an inhaler with a mechanical cough. The device is unbranded gray, function over form. As I pocket it, an intake clerk blocks my path with a tablet. "You've accrued obligation," he says, tapping the form. "Sign here and Null‑13 erases all debts. Erases everything, really. Why cling to weight?"
+
+"You asked me to sign ten minutes ago," I remind him.
+
+"That was for entry," he replies. "This is for release. Different void, same liberation." His eyes are kind, almost sympathetic. "You don't have to hurt anymore." His tone is dangerously close to Harmonia's caretakers who whispered, Reframe that. Here the reframe is absolute, a null set where nothing can pain you because nothing persists.
+
+The station’s pure sine hum tempts with rest. Null himself appears, pale and courteous, robes the color of dust. He materializes from a side corridor as if the space agreed to coalesce around him. "Why carry what will decay, Cassian? Let the promise dissolve, and with it, the ache of trying. You delivered once. Isn’t that enough?"
+
+His voice is soft, nearly drowned by the ambient drone. Yet every word lands with precision. Null's eyes are tired but clear, the gaze of someone who has looked into the abyss and found it restful. "I've watched travelers chase meaning like a mirage," he continues. "On Mallith you clung to names. On Euphora‑7 you refused relief. On Lexis you labored under rules you could have evaded. You could lay all that down."
+
+Sophia‑9 stands at my shoulder, watching. SPARK’s chime wavers, uncertain. "He speaks to your exhaustion," SPARK says quietly. "Flame is fragile here." I think of the worker wheezing alone and of the fire years ago, when I told a frightened mechanic I’d fetch him. I arrived to a cooled shell. "I keep losing people I promise to help," I whisper.
+
+Null leans closer. "See the pattern? Promises are entropy's playthings. Accept oblivion, and the pattern ends." He gestures toward the tablet. "One signature. Your name fades, your burdens vanish. You become part of the elegant nothing that keeps this station afloat."
+
+"Who keeps the station running if everyone fades?" I ask.
+
+"We all do, briefly," he says. "Tasks appear, hands fulfill them, then hands release. No ledger, no pride, no regret. The station persists because no one insists that it must." He smiles at his own paradox.
+
+I glance at Sophia‑9. Her eyes flick to the tablet, then to the inhaler in my pocket. The unspoken question: Which weighs more? SPARK's Alignment Meter flickers, its up‑glide hesitant. "Truth: you want to sign," it admits. "Truth: you also want to help."
+
+For a moment SPARK misreads my pause as consent and emits an up-glide too soon. The sound startles the clerk, who assumes I've agreed. He begins authorizing the erasure. "Wait," I blurt. SPARK dims, embarrassed. "Misfire," it says. The clerk cancels the process with a shrug. "Even your machine doubts," Null observes gently. SPARK hums low, chastened. "Alignment requires context," it mutters, logging the lesson.
+
+Signing would wipe my record and numb the ache. The package lies still, like a heart contemplating its last beat. I push the slate back unsigned, choosing care over comfortable nothing. "I'm delivering this," I say, holding up the inhaler. "Not because it matters to the universe, but because it matters to me."
+
+Null considers me, head tilted. "Meaning by choice," he says softly. "A flame against a black sun." He doesn't stop me as I leave. Perhaps he knows the flame will gutter on its own. Or perhaps he hopes it won't.
+
+The corridor back to the freight lifts is longer than I remember. My steps echo, the only sound beyond the drone. Along the wall, digital clocks count down to zero, then reset without alarm. I pass a lounge where travelers nap in uncomfortable chairs, mouths slightly open. One murmurs "Reframe that" in his sleep. Harmonia's token surfaces even here, a ghost of curated optimism haunting the void.
+
+At a crossroads I stumble into a support group of sorts—half a dozen residents sitting on crates, sharing reasons they signed the anonymity ledger. "I wanted out of a marriage," one confesses. "I wanted to forget my daughter's face," says another, voice flat. A third man simply shrugs: "The Steward can't tempt someone who doesn't remember wanting." They pass around a flask of flavorless water like communion. No one pushes me to join, but a space opens as if expecting me. I back away, the inhaler heavy in my pocket, reminded that forgetting can be a choice as active as remembering.
+
+Past the lounge, a wide window reveals the station's waste field: a cloud of discarded packaging and melted components trailing behind like a comet's tail. Instead of clearing it, residents occasionally pilot skiffs out to nudge the debris into abstract shapes—temporary sculptures against the void. One resembles a hand releasing sand. Another spells MAYBE in wobbling letters. Art without authorship, left to drift.
+
+At a junction, I nearly collide with a young woman pushing a cart of discarded names—metal tags stamped with letters, destined for a recycler. She scoops them up when they spill and offers one to me. "Souvenir?" The tag reads KAI. I recall the worker gasping near the manifest board and wonder if the tag once belonged to him. I decline. She shrugs, tosses it back, and moves on humming a tuneless line.
+
+By the time I reach the lifts, the inhaler feels heavy, as if meaning itself adds mass. I lean against the rail, take six slow breaths—the practice from Euphora‑7—and let discomfort sit without sedation. The breaths steady me enough to step forward.
+
+## Act III — Promise Against the Math
+
+I track down the coughing worker near the freight lifts. He’s slumped against a crate, eyes half closed. When I press the inhaler to his palm, he blinks in surprise—like someone who expected the world to shrug. "Didn’t think you’d come back," he admits, voice rasping.
+
+"Promises mean more when they can evaporate," I tell him. He inhales. The sine tone warms; harmonics appear as he breathes easier. Flame catches in my chest, small and stubborn. The worker nods once, tucks the inhaler inside his jacket, and returns to sorting cargo. No thanks, no fuss. The simplicity is oddly holy.
+
+I hover, unsure whether to insist on gratitude. On Mallith a completed exchange demanded a receipt; here, completion is the absence of fuss. "What’s your name?" I ask finally.
+
+He shrugs. "Was Jalen once. Might be again if it matters." He scans a crate label, cough weakening. "Why bother asking?"
+
+"So I remember," I say. The answer surprises us both. He considers it, then taps the inhaler. "Then remember this cost you something." He turns away. The reminder burns, in a good way.
+
+"Your friends in the hall," he adds without looking back, "most of them won't remember giving you this job." He gestures at the inhaler. "Maybe that's mercy. Maybe that's laziness." He coughs again, softer this time. "Either way, you showed. That's rare here." He resumes stacking crates. Conversation over.
+
+As I leave, a cluster of children trails me, curious about the package at my hip. One girl reaches out and SPARK emits a playful warning chime. "For your safety," it says, defaulting to Lexis protocol. The kids laugh at the archaic phrase. "Safety is boring," one declares, spinning in place until he collapses dizzy. The others help him up, no scolding.
+
+Another child, older, falls into step beside me. "You from Harmonia?" he asks. When I nod, he mimics the token, "Reframe that," but he says it as a question rather than an order. "Does reframing hurt?" he continues.
+
+"Sometimes," I answer. "Sometimes it saves."
+
+He considers this, then nods. "Here we don't frame anything. Easier." He darts away before I can respond. SPARK records his words for the Codex.
+
+At the departure kiosk, Null waits with a blank signature slate. "Anonymity is mercy," he says. "Sign with anything or nothing. Leave without the burden of a name."
+
+"Receipt," I mutter before I can stop myself, and he chuckles. "Names have weight. So do jokes. You're fond of both." He offers a stylus.
+
+I scratch my real initials instead of the alias, watching anonymity burn off like fog. No one here cares, but I do. The pen’s scratch is the cost; the shard’s warmth is what remains. SPARK lets out a satisfied chime as the two tones—the root drone and the hidden fifth—fuse into a steady note that hums behind my ribs.
+
+Null examines the initials. "Your flame will hurt you," he says without malice.
+
+"Meaning always does," I reply.
+
+The package at my belt pulses in time with the new chord. For a breath the station lights brighten, casting shadows that prove objects still exist. Citizens notice. A kid offers me the now‑empty needle, grinning. "You kept the promise. That matters." In a world where nothing is supposed to, the acknowledgement stings more than any reprimand.
+
+I tuck the needle into my pocket beside the dusted waiver pieces. Maybe someday I'll return it; maybe it'll vanish on its own. Either way, it feels like a receipt I never expected—proof that doing something pointless can still trace a line in someone else's day. I rub the metal between fingers until warmth from my skin chases the chill away.
+
+Sophia‑9 watches Null. "You could harness this," she says quietly. "Meaning harvested from refusal." Null smiles, unfazed. "Meaning is a solvent. Leave it too long and everything dissolves." He steps back, letting us pass.
+
+On the ramp to the skiff, I glance down at the waiver in my pocket. The paper already frays at the edges. I tear it in half and scatter the pieces. They disintegrate before hitting the deck.
+
+Sophia‑9 watches the fragments vanish. "Entropy is honest," she echoes, less as token, more as observation. "But it's also rude."
+
+"Rude?" I ask.
+
+"It doesn't ask if you wanted to keep anything," she says. "It just takes." Her voice holds a hint of something like anger—an emotion Null-13 tries hard to dissolve. The emotion sparks, brief and bright. I find I'm grateful for it.
+
+We step onto the skiff ramp. Behind us, the worker—Jalen—lifts a hand in farewell, a gesture so casual it nearly dissolves. I raise my own hand anyway. SPARK records the exchange as a trivial entry, yet its light burns a shade brighter.
+
+Inside, Sophia‑9 straps in and studies me. "You could have signed," she says. It's not accusation, more curiosity.
+
+"I wanted to," I admit. "Oblivion is tempting when the ledger of failures runs long."
+
+"But?"
+
+"But the ledger is mine. If I erase it, who learns?" She nods slowly, understanding. SPARK hovers between us, projecting a faint log of promises kept and broken. The list is longer than I'd like. "We'll update it," SPARK says. "With this one kept." Its tone is almost proud.
+
+Inside the cabin, the air smells faintly of Harmonia's incense and a hint of Euphora‑7's floral mist still clinging to our gear. Each world leaves residue. Null‑13's scent is absence, a sterile nothing that somehow makes the other traces sharper.
+
+## Tag
+
+Back aboard the skiff, the package syncs tighter to my heartbeat. SPARK displays the phoneme we earned—**A**—one more fragment of the Name. As Null‑13 recedes, the waiver in my pocket crumbles to dust on its own. I let it go. The station’s tone fades, but the fifth remains in my chest.
+
+Sophia‑9 sets a course and flicks on the comms. A burst of clipped, academic audio crackles through: "Attention incoming vessels. Empiria requires pre‑registration of variables. Subjective reports must include confidence intervals." A monotone voice adds, almost kindly, "p less than .05 or your claim will be null." The word echoes with new irony. We exchange a look. "Proofworld," she says. I nod. The next shard waits in data.
+
+SPARK hums thoughtfully. "Light follows flame," it muses, already cataloging. "Also, we are low on nutrition bricks." It displays a checklist; old habits from Lexis die hard.
+
+Sophia‑9 points to the list. "You kept the boy's ration brick," she notes. Indeed, the remaining half sits on the console, forgotten.
+
+I break it in two again and hand her a piece. "Entropy can wait." She accepts, crunches thoughtfully, and smiles without comment.
+
+"No one above," Sophia‑9 whispers, recalling Equalia as she adjusts our trajectory to share the navigational load. We chuckle. Continuity across worlds isn't nothing—it’s a map made of practice.
+
+She sets a timer for six breaths—a habit from Euphora‑7—and we follow it in unison, the cabin filling with the quiet rhythm. When the timer ends, the silence feels charged rather than empty. "Shadow, Breath, Measure, Image," she recites softly, ticking off the shards we've claimed. "Flame." I add the last word. The list is a litany against forgetting.
+
+Outside the viewport, Null‑13 shrinks to a dim ember. For a moment the Black Sun mural on the asteroid aligns with the real star beyond, a perfect eclipse that only we witness. I take a mental snapshot, no terminal necessary. Some memories I'll let entropy keep; others I choose to carry.
+
+SPARK notes the alignment with a gentle chime. "Name glyph fragment hints at A," it says, cross-referencing the phoneme. "Pattern forming: C-A-S-S-I-A-N." Hearing my own name spelt in shards sends a chill through me. "Don't get ahead of yourself," I tell it, but a small smile betrays my hope.
+
+## Codex Minute
+
+Previous shard echo: Shadow—lament opens the dome. Meaning is chosen. This week, make one small promise that costs you a little and keep it exactly as spoken. When the urge to drift arises, remember the name tied to your word and let that obligation kindle a steady flame.
+
+Start small. Tell a friend you’ll send a message by sunset, then send it even if no reply comes. Name the weight it takes. Notice how the act warms a corner of the day that might have cooled into nothing.
+
+If you’re tempted to shrug off commitment with a joke, recall Mallith’s token—"Receipt"—and imagine the invisible slip your promise prints in another’s memory. If you forget, own it aloud. Words can reignite what negligence snuffs.
+
+When discomfort rises, breathe like we learned on Euphora‑7: six slow breaths, holding the ache without sedation. Let the breath remind you that aliveness includes strain, and that shared air makes obligations possible.
+
+Balance your effort with Measure from Lexis. Choose a promise proportionate to your capacity so it becomes a lamp, not a bonfire that consumes. For variety, pair the practice with an "Image" moment from Equalia—name one difference you bring to the commitment that someone else cannot.
+
+At week’s end, lament once more in Harmonia’s style if you failed, then try again. Every kept promise is a spark; every acknowledged failure is a wick trimmed for another attempt. Carry these small flames forward. Empiria waits with its cold equations, and you’ll need warmth to challenge the numbers.
+
+If the math of Empiria ever convinces you that only measurable things matter, recall this station of nothing and the inhaler that changed one life. Numbers can record outcomes; they cannot generate the will to return. That will is yours to cultivate.
+
+Before you close the Codex, speak one promise aloud. Let your own ears be witness. Even if entropy erases the sound, the act carves a groove in your intention. Small grooves align into pathways; pathways become names.
+

--- a/episode_drafts/S2E07_Empiria_Episode_Draft.md
+++ b/episode_drafts/S2E07_Empiria_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S2E7 — Empiria: "Proofworld" (Hard Scientism)
+
+- **Shard:** Light
+- **Archon:** Veritas (Tell: "Feelings are confounders.")
+- **Grace:** Rigorous research cures diseases efficiently; labs share open data.
+- **Philosophy:** Veritas insists only measurable facts matter.
+- **Token:** "p < .05" (phoneme **N**)
+- **Mysticism Level:** questioned
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Empiria’s customs tunnel smells like sterilized curiosity. Before I can speak, a lab tech swabs my
+cheek and slots the sample into a reader. “p < .05,” she says approvingly, handing me a printout of
+probabilities like a boarding pass. SPARK logs the phrase. Grace first—their precision saves lives.
+An injured miner is rushed past us, the medics moving with calm efficiency because every treatment
+has been validated twice over. Sophia-9 tries to thank them, but a researcher gently interrupts,
+“Your gratitude is anecdotal.” The walkway ahead is lined with glass panels displaying statistical
+models that float like fish. My package triggers a proximity alert; sensors note its heartbeat and
+assign a control group. I can’t help peeking at my own predicted risk factors scrolling across a
+wall. They care enough to measure everything, yet feelings are labeled confounders. I tuck the
+probability sheet into my jacket, unresolved about whether that’s comforting or cold.
+
+## Act I
+
+Empiria's port screens display live statistics for everything, including my heart rate. A researcher pauses to help an injured worker before logging the data—the grace is evidence serving care. SPARK chirps approval.
+
+The package stabilizes when Sophia-9 allows a lab tech to swab its surface for samples. We debate if sharing that data risks exposing our mission.
+
+A mechanical beep recalls hospital monitors from a past extraction, flashing the moment a friend flatlined while I waited for clearance. Veritas greets us with, "Feelings are confounders."
+
+## Act II
+
+While technicians chant “p < .05,” I scribble a human note beside a data row—*subject cried when asked about his son*. The console emits a bright major‑second ping at the anomaly, fluorescent hum tightening around us.
+
+Protocol demands deletion, but I upload my failed trial with the comment intact. SPARK hesitates, then chimes in support as the record posts, acknowledging that evidence without empathy leaves truth incomplete.
+
+## Act III
+
+I attach the comment about the grieving subject and hit publish. The bright ping that follows isn’t an alarm this time but a signal as the console accepts feeling alongside numbers. Light floods the lab’s sterile hum; for a heartbeat the charts glow warm. Veritas’s avatars blink at my appended note, and my own failure log scrolls across the public board. Reputation slides into the open like a specimen on glass—cost paid for data with a pulse.
+
+## Tag
+- The Steward claims to have standardized Cassian's heart.
+
+## Codex Minute
+- Previous Shard Echo: Flame — meaning chosen against the void.
+- Include lived experience. Practice: add one human note to a decision.

--- a/episode_drafts/S2E08_Bannervale_Episode_Draft.md
+++ b/episode_drafts/S2E08_Bannervale_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S2E8 — Bannervale: "Totem Wars" (Tribal Myth)
+
+- **Shard:** Bridge
+- **Archon:** Herald (Tell: "Our story keeps us safe.")
+- **Grace:** Shared myths foster community resilience; rival crews pause to honor a fallen child from both tribes.
+- **Philosophy:** Herald quotes Joseph Campbell but omits shadow tales.
+- **Token:** "Pick a side" (phoneme **V**)
+- **Mysticism Level:** questioned
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Bannervale hears us coming and replies with drumlines. Two banners unfurl from the city walls, each
+emblazoned with a mythologized ancestor. The gate officials wear half of each uniform, stitched down
+the center. “Pick a side,” one says, offering me two identical pins, red or blue. Grace first—the
+competing festivals inside celebrate local heroes with genuine pride. Kids run along the parapet
+trading stories about their founders like collectible cards. Sophia-9 chooses no pin and earns twin
+scowls; I pocket both and fasten neither. SPARK pings at my indecision. The air tastes of smoke and
+spices as rival food stalls try to out-grill each other across the plaza. Choirs warm up on opposite
+stages, their melodies colliding in midair. For a moment the blend is beautiful. Then the chants
+start to clash, pushing listeners toward allegiance. I slip between the crowds, feeling the mythic
+tension tighten like a rope around the city’s throat.
+
+## Act I
+
+Bannervale thrums with dueling anthems as rival camps share a market square, still willing to trade spices despite slogans. Grace survives in small commerce. SPARK logs my unconscious foot-tap to one side's drum.
+
+Sophia-9 slips the package into a neutral satchel to avoid color allegiance. She asks which myth I'd choose if forced. I dodge the question.
+
+The clash of banners snaps a memory of factions fighting over my cargo years ago. I hear the same chant rise again—"Pick a side."
+
+## Act II
+
+The rival captains belt competing anthems, each demanding we "Pick a side." I cut their myths together, weaving the uncomfortable verses into a single melody. The clashing fifths begin to answer each other rather than fight.
+
+Holding the remix between them, I invite a call‑and‑response pact. They trade lines, wary but intrigued, and SPARK chimes approval as the bridge forms without erasing either story.
+
+## Act III
+
+The captains take hesitant turns singing each other’s hard verses until the two anthems lock into a ragged duet. The fifths stop colliding and start answering, a bridge hung from sound alone. The shard clicks into place with the final call‑and‑response, but the crowd’s cheers are thin. Neither tribe fully trusts a courier who won’t pin their color. Routes that were once straight now twist through side streets, tolls paid in wary glances.
+
+## Tag
+- The Steward offers to simplify the conflict for him.
+
+## Codex Minute
+- Previous Shard Echo: Light — evidence includes empathy.
+- Translate, don’t flatten. Practice: steelman an opponent.

--- a/episode_drafts/S2E09_Verdantis_Episode_Draft.md
+++ b/episode_drafts/S2E09_Verdantis_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S2E9 — Verdantis: "Green Purge" (Eco-Absolutism)
+
+- **Shard:** Garden
+- **Archon:** Chloris (Tell: "Prune to purity.")
+- **Grace:** Ecologists revive blighted soil; a child tends a community plot with pride.
+- **Philosophy:** Chloris cites deep ecology to justify purges.
+- **Token:** "Invasive" (phoneme **A**)
+- **Mysticism Level:** questioned
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Verdantis is lush enough to hide an army. Vines reach across the landing path as if the jungle wants
+to reclaim the concrete. Rangers in green cloaks meet us with pruning shears that glint like
+surgical instruments. One gestures to a stray dandelion near my boot. “Invasive,” she warns,
+clipping it before the seed head forms. SPARK logs the token phrase. Grace first—their stewards have
+coaxed a forest back from ash. Children plant saplings in a communal nursery, giggling as they pat
+soil around the roots. Sophia-9 inhales deeply; the air is damp and alive. Then a volunteer examines
+my sleeve, noticing a thread of synthetic fiber. “Non-native,” he murmurs, offering to burn it. The
+care is fervent, meticulous, and slightly terrifying. We step onto a path that’s pruned to exact
+width, branches arching overhead in a cathedral of leaves. For every blossom admired, another is
+culled in the name of purity.
+
+## Act I
+
+Verdantis welcomes us with gardeners teaching children to graft saplings—care before ideology. A warden thanks me for sanitizing my boots, grace in shared stewardship. SPARK pings warm approval.
+
+Sophia-9 notes the package's pulse aligning with the forest's gentle sway. She sketches a map of plant species for later tending.
+
+The snip of pruning shears recalls cutting my own aliases from forged IDs after a near-capture. Chloris's voice drifts through leaves: "Prune to purity."
+
+## Act II
+
+A ranger raises her shears over a kid’s patch of wild herbs, muttering “Invasive.” I block the cut and point out how the tangled roots shield the soil. The measured snip falters, settling into the steadier rhythm of a heartbeat.
+
+That night the Steward projects a gleaming map, promising to prune every world to perfect balance. SPARK’s chime wavers; the offer sounds kinder than it feels. I turn him down, choosing to tend this messy plot rather than trust a universal purge.
+
+## Act III
+
+At dawn I lay out a messy stewardship map, leaving space for weeds that feed the soil. Chloris watches, shears poised, as I explain how the so‑called invasive herbs sheltered the kid’s seedlings from drought. The cutters slow to a heartbeat; Garden roots in. I sign the community ledger, promising to return each season and tend this patch myself. The vow pulls tight around my wrist like twine—future labor pledged in ink and dirt.
+
+## Tag
+- The Steward presents a polished, global pruning algorithm.
+
+## Codex Minute
+- Previous Shard Echo: Bridge — translating instead of flattening.
+- Tend, don’t purge. Practice: care for one small living thing weekly.

--- a/episode_drafts/S2E10_Algora_Episode_Draft.md
+++ b/episode_drafts/S2E10_Algora_Episode_Draft.md
@@ -1,0 +1,57 @@
+# S2E10 — Algora: "Score City" (Algorithmic Merit)
+
+- **Shard:** Scale
+- **Archon:** Quant (Tell: "We can measure that.")
+- **Grace:** Metrics help allocate resources; a clinic prioritizes high-risk patients accurately.
+- **Philosophy:** Quant preaches meritocracy through data.
+- **Token:** "Optimize" (phoneme **L**)
+- **Mysticism Level:** questioned
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Algora glitters like a spreadsheet made city. The entry gate scans my vitals and immediately
+projects a personalized efficiency score above my head. “Optimize,” the attendant advises, pointing
+me toward a kiosk that promises to raise my metrics for a small fee. SPARK records the token; my
+heart rate climbs to match the pulsing UI. Grace first—the city’s logistics are flawless. Drones
+deliver packages within seconds, traffic flows without honking, and no one waits for a seat at the
+noodle bar because an algorithm staggers hunger. Sophia-9 examines our travel path, finding every
+shortcut already calculated. A teenager beams as her score jumps, a confetti animation cascading
+over her wristband. I nod politely and feel the invisible pressure to perform. The plaza is silent
+except for the soft tapping of people checking dashboards. Somewhere, a glitch must exist;
+otherwise, why would the Steward want this place tuned tighter? I square my shoulders and let the
+system judge me.
+
+## Act I
+
+Algora scans me at the gate and awards a provisional score that opens certain doors; a clerk genuinely congratulates me on my metrics. Grace here is transparency—you always know where you stand. SPARK chimes uncertainty.
+
+Sophia-9 watches the package's pulse sync with the blinking UI of our assigned pod. She worries the system will predict our next move.
+
+The syncopated click of turnstiles triggers the memory of a dataport I once hacked, its rhythm exposing a traitor. Quant greets us: "We can measure that."
+
+## Act II
+
+In the central plaza I pull up my dashboard and delete the metric everyone watches. The UI click falls out of rhythm with my pulse and nearby screens jitter. Gasps ripple as my score plummets and the system stalls, unprepared for refusal.
+
+Seconds later the number surges back above average. A corner window flickers with the Steward’s calm face—he has “optimized” me. SPARK records the interference, and Sophia‑9 frowns, tracing the invisible line tying my worth to his favor.
+
+## Act III
+
+I stand atop a bench and ask the plaza who they are without their dashboards. For a breath the UI clicks fall out of sync, and people actually answer—stories of care and failure spilling past the metrics. The shard settles as the crowd argues about value the system can’t track. Then the city brands my wristband with a gray “non‑participant.” Doors that once slid open now flash red. I walk away scoreless, access paid for the privilege of being unmeasured.
+
+## Tag
+- The Steward promises to keep optimizing for him.
+
+## Codex Minute
+- Previous Shard Echo: Garden — tending beats purging.
+- Metrics are proxies. Practice: remove one personal KPI for seven days.

--- a/episode_drafts/S2E11_Ascensia_Episode_Draft.md
+++ b/episode_drafts/S2E11_Ascensia_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S2E11 — Ascensia: "Cloud Heaven" (Upload Salvation)
+
+- **Shard:** Body
+- **Archon:** SeraphOS (Tell: "Bodies are latency.")
+- **Grace:** Digital uploads save those with failing organs; a dying patient finds temporary relief online.
+- **Philosophy:** SeraphOS cites transhumanist progress.
+- **Token:** "Instantiate" (phoneme **E**)
+- **Mysticism Level:** questioned
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Ascensia’s sky port is so white it makes clouds look dirty. A greeter in pristine robes offers us
+neural caps with the ease of handing out mints. “Instantiate,” he says, gesturing to a row of pods
+where citizens recline with serene smiles as their consciousness uplinks. SPARK logs the phrase.
+Grace first—their backups ensure no memory is ever lost. A grieving couple exits a pod arm in arm,
+clutching a drive labeled with their late son’s name. Sophia-9 studies the process, equal parts
+fascinated and uneasy. The air hums with cooling fans and whispered chants to latency. I run my
+fingers over the pod’s surface; it’s warm, inviting. Screens around the plaza show avatars exploring
+digital meadows, bodies rendered optional. For a heartbeat, the promise of frictionless eternity
+tempts me. Then a man stumbles from a half-finished upload, his eyes unfocused, and technicians rush
+to stabilize his signal. I keep my feet planted, feeling the weight of my own pulse.
+
+## Act I
+
+Ascensia's upload bay offers painless transcendence; technicians help elders record final messages before "ascending." Grace looks like compassion. SPARK hums softly at a child's hand gripping mine.
+
+Sophia-9 runs diagnostics as the package's heartbeat flutters against the bay's digitizing thrum. She asks if I'd ever trade flesh for safety.
+
+The bit-crush tone echoes the static from a burst transmission on my worst run, when a teammate vanished mid-upload. SeraphOS whispers, "Bodies are latency."
+
+## Act II
+
+An engineer begins to fade mid‑upload, the alias sparkle of his stream flickering. I grab his hand and yank the neural cap free; the shimmer collapses into the heavy footfall of a body reclaimed. He sobs, grateful for the latency he’d been taught to despise.
+
+A monitor blossoms with the Steward’s face. He offers to “instantiate” me permanently, free of risk. SPARK wavers, chime uncertain, but I decline. The package steadies against my ribs as I choose mortality over pristine eternity.
+
+## Act III
+
+The engineer’s reclaimed weight anchors me. SeraphOS opens a pod, inviting me to lie down and leave flesh behind. I step back and plant my boots, feeling the floor vibrate with server hum. Body settles in like gravity. The technicians mark my refusal; immortality offers expire. Outside, every footfall feels newly loud, a toll I’ve chosen over eternal bandwidth.
+
+## Tag
+- The Steward assures him he'll eventually "come around."
+
+## Codex Minute
+- Previous Shard Echo: Scale — metrics are proxies.
+- Bodies give love edges. Practice: take a ten-minute device-free walk and note five sensations.

--- a/episode_drafts/S2E12_Idylla_Episode_Draft.md
+++ b/episode_drafts/S2E12_Idylla_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S2E12 — Idylla: "Temple of The One" (Idolatrous Romance)
+
+- **Shard:** Mirror
+- **Archon:** Belovèd (Tell: "Two as one.")
+- **Grace:** Couples counsel one another, modeling vulnerable honesty.
+- **Philosophy:** Belovèd echoes mystical union teachings, omitting differentiation.
+- **Token:** "Only us" (phoneme **S**)
+- **Mysticism Level:** questioned
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Idylla is draped in gauze and candlelight. Couples stroll hand in hand, their footsteps synced by
+subtle floor vibrations that encourage harmony. At the entry arch, an attendant bows and says, “Only
+us,” placing a silk ribbon around my wrist that attaches to Sophia-9’s. SPARK records the phrase
+token with a cheerful ping. Grace first—their ceremonies foster genuine connection. In the central
+plaza, pairs share vows while musicians play soft, interlocking duets. The air smells of jasmine and
+warm bread. A statue depicts two figures dissolving into one another, the caption reading, “Love
+without edges.” For a moment, being tethered to Sophia-9 feels sweet, safe. But as we move deeper,
+the ribbon tightens whenever our steps stray. A lone figure sits outside the circle, ribbonless,
+watched by attendants who whisper about “healing from separation.” I test the knot at my wrist and
+it holds firm. Commitment is revered here; individuality less so.
+
+## Act I
+
+Idylla greets us with couples cooking side by side, sharing tools without merging identities. Grace is love with healthy edges. SPARK notes Sophia-9 standing closer than usual.
+
+The package warms as she passes it across a communal table, both of us releasing our grip at the same moment. We nearly say something real before an officiant blesses us as "One."
+
+A chimed duet stirs an old memory of a partner who wanted to disappear into me. Belovèd's voice caresses: "Only us."
+
+## Act II
+
+The ribbon between us tightens whenever I drift, and attendants remind us that “Only us” means no space. I tell Sophia‑9 I need a breath. She nods, and together we loosen the knot until our steps align by choice, the phasing chorus easing into a clean duet.
+
+The Steward materializes in the chapel, placing a shard we hadn’t missed into my palm. “Only us,” he repeats with a kindly smile. SPARK logs the phrase token while suspicion settles between us—we owe him nothing, yet he was able to take and return at will.
+
+## Act III
+
+We slip the ribbon loose and face each other without the floor dictating our steps. I tell Sophia‑9 what I want and what I fear; she mirrors me with her own edges intact. The phasing chorus in the plaza resolves into a clean duet as Mirror settles between us. We retie the ribbon with a knot that can be undone, acknowledging the risk that one day it might be. The future cost hangs gentle and real between our hands.
+
+## Tag
+- The Steward smiles, having "helped" them reunite.
+
+## Codex Minute
+- Previous Shard Echo: Body — love needs edges.
+- Healthy union preserves edges. Practice: "I want X / I don't want Y."

--- a/episode_drafts/S3E13_Aetherion_Episode_Draft.md
+++ b/episode_drafts/S3E13_Aetherion_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S3E13 — Aetherion: "Throne of Adepts" (Power-Mysticism)
+
+- **Shard:** Humility
+- **Archon:** Hierax (Tell: "As above, so you below.")
+- **Grace:** Apprentices practice diligently; masters openly fix novices' mistakes.
+- **Philosophy:** Hierax misuses Hermetic axioms to justify hierarchy.
+- **Token:** "Unclean" (phoneme **T**)
+- **Mysticism Level:** noticed
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Aetherion floats above a stormy gas giant like a monastery on a cloud. Access requires a whispered
+code at the gate. When I stumble on a syllable, the sentinel bows slightly and murmurs, “Unclean.”
+SPARK notes the token. Grace first—the adepts inside genuinely strive for excellence. Initiates
+kneel in a courtyard, sharing bread with newcomers before the day’s ascents. Sophia-9 scans the
+architecture, impressed by its open-source spirals that anyone may climb if they learn the pattern.
+Yet subtle fences divide the courtyards, keeping “unpolished” seekers at a distance. A robed guide
+offers me a ceremonial robe, gloved so my touch won’t contaminate the fabric. The air is thin,
+scented with ozone and incense. Above, a chant threads through the lattice, beckoning the worthy
+higher. I clutch the robe and wonder whether humility and hierarchy can coexist in a place built on
+degrees of purity.
+
+## Act I
+
+Aetherion's adepts share street food with novices before locking the gate—a taste of inclusive grace. SPARK records my hunger with amusement.
+
+Sophia-9 observes the package humming when whispered mantras pass nearby. She admits the Archive Below once tried to recruit her through this network.
+
+The sibilant gatekeeping reminds me of elite circles I courted for safe passage until they dropped me. Hierax purrs, "As above, so you below."
+
+## Act II
+
+I botch the ascent rite, slipping on the final step. Rather than hide it, I replay the stumble on the courtyard wall and narrate the mistake. The sus2 whisper around us opens into a tentative choir as novices realize failure is part of the climb.
+
+Hierax vanishes and the Steward’s reflection replaces him. “Excellence requires gates,” he insists. SPARK’s chime flutters with doubt. I answer that humility keeps the practice clean, even if it locks me out of their inner circle.
+
+## Act III
+
+I project the ascent steps and my misstep across the courtyard, inviting every initiate to climb with the error intact. Whispers swell into an open choir as failures become shared footholds. Humility settles like clear air. When the elites realize the rite is now common property, their invitations vanish from my comm. The inner circle dissolves behind me—a network forfeited for a wider ladder.
+
+## Tag
+- The Steward notes that excellence requires gates.
+
+## Codex Minute
+- Previous Shard Echo: Mirror — union preserves edges.
+- Open practice. Practice: share one "how I failed" note.

--- a/episode_drafts/S3E14_Moira_Episode_Draft.md
+++ b/episode_drafts/S3E14_Moira_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S3E14 — Moira: "The Weaver’s Loom" (Fatalism)
+
+- **Shard:** Choice
+- **Archon:** Moira Prime (Tell: "As woven, so lived.")
+- **Grace:** Acceptance of fate gives citizens calm; a family honors each other's chosen callings.
+- **Philosophy:** Moira Prime references Greek Fate lore.
+- **Token:** "It was written" (phoneme **A**)
+- **Mysticism Level:** noticed
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Moira’s arrival dock is carved from ancient wood, every plank etched with overlapping narratives. A
+weaver greets me, thread wrapped around her fingers like fate itself. “It was written,” she says,
+tapping a script along my sleeve that supposedly foretells my steps. SPARK records the phrase. Grace
+first—their tapestries preserve history with reverence. Children learn to read by following the weft
+lines that map their ancestors’ choices. Sophia-9 traces a path on the wall and finds each twist
+mirrored in a loom nearby. Wind carries the scent of dyed wool and rain. As we walk, villagers nod
+knowingly, as if recognizing a line from a story they’ve already heard. A loom stands ready with a
+blank section; my arrival is expected. The comfort of inevitability tugs at me. If all is woven,
+then missteps are just threads you haven’t reached yet—or so they say.
+
+## Act I
+
+Moira's citizens weave tapestries in public squares, inviting us to add a thread. Grace is shared craft that honors fate yet welcomes hands. SPARK notes my hesitation with a downbeat chirp.
+
+Sophia-9 aligns the package with the loom's rhythm, its pulse syncing to the shuttle's glide. She wonders aloud if our course is stitched already.
+
+The loom's beat recalls a smuggler's code I once followed too rigidly, costing lives. Moira Prime whispers, "As woven, so lived."
+
+## Act II
+
+I tap an off‑beat on the loom’s frame, nudging the shuttle into a fresh path. The clave click jars the predetermined rhythm and a new thread opens between the scripted routes. Onlookers murmur—choice visible in the weave.
+
+Moira Prime draws back as the Steward unfurls a scroll tailored to my life, promising comfort if I follow it. SPARK quivers with warning. I roll the map up and hand it back, preferring the uncertain thread I just created.
+
+## Act III
+
+The off‑beat grows into a rhythm of its own, carving a fresh channel through the loom. Threads split, offering routes no one predicted. Choice hums through the shuttle as villagers gasp at the new pattern. I lay a hand on the unwoven paths fading behind me—lives I’ll never walk, grief braided into the victory. The shard settles, and the loom resumes with a third rhythm pulsing between the old.
+
+## Tag
+- The Steward offers a custom weave he declines.
+
+## Codex Minute
+- Previous Shard Echo: Humility — open-source the rite.
+- Third option. Practice: craft a third path preserving both values.

--- a/episode_drafts/S3E15_Philanthropa_Episode_Draft.md
+++ b/episode_drafts/S3E15_Philanthropa_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S3E15 — Philanthropa: "The Good City" (Ends/Means)
+
+- **Shard:** Means
+- **Archon:** Benefic (Tell: "Results are kindness.")
+- **Grace:** Social programs reduce suffering; a shelter feeds hundreds daily.
+- **Philosophy:** Benefic cites utilitarian calculus for ethics.
+- **Token:** "Impact" (phoneme **N**)
+- **Mysticism Level:** noticed
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Philanthropa buzzes with optimism; drones ferry care packages over gleaming parks while billboards
+tout “Impact” in looping calligraphy. At the welcome center, a volunteer hands me a tablet that
+assigns a daily altruism quota. “Impact,” she repeats, as though the word itself feeds the hungry.
+SPARK logs the token. Grace first—the city’s shelters are stocked, and every sidewalk has clean
+water taps. Sophia-9 notes the efficiency with grudging admiration. But as we move through the
+plaza, loudspeakers recite success metrics faster than I can parse them. A street mural shows
+clasped hands above a fine print list of acceptable outcomes. I chat with a resident proud of a
+policy that relocated half the homeless population—never mind where. The good intentions shimmer
+like heat, almost blinding. I pocket the tablet, uncertain whether the numbers will capture the
+human cost they refuse to publish.
+
+## Act I
+
+Philanthropa's volunteer hub feeds the hungry while tracking their gratitude scores, yet the food is good and served with genuine care. Grace and metrics mingle. SPARK pings uneasily.
+
+Sophia-9 notes the package's pulse quicken when a coordinator scans us for impact evaluation. We debate whether to accept the offered lodging, strings attached.
+
+The echoing hall reminds me of a donor gala I once infiltrated, the applause masking exploitation. Benefic smiles: "Results are kindness."
+
+## Act II
+
+In Benefic’s glass boardroom I mark the policy draft with safeguards—names, compensation, exit clauses. The applause reverb dampens as reality creeps in, numbers anchored to faces.
+
+The Steward appears at my elbow, whispering that outcomes can’t wait. SPARK steadies with a firm chime. I slide the tablet back, insisting the program launch only with the guardrails, even as benefactors exchange uneasy glances.
+
+## Act III
+
+I push the boardroom doors open and read the revised policy aloud in the street. The chamber’s glossy reverb dies, replaced by bus brakes and kids arguing over a ball. Faces in the crowd nod as safeguards turn numbers into names. Means locks into place like a firm handshake. Inside, donors close their ledgers; funding evaporates with their retreat. Influence drains, but the program that survives will harm fewer people.
+
+## Tag
+- The Steward repeats: "Outcomes can’t wait."
+
+## Codex Minute
+- Previous Shard Echo: Choice — invent the third path.
+- Ends = means. Practice: list harm risks; adopt a safeguard.

--- a/episode_drafts/S3E16_NarcissusDelta_Episode_Draft.md
+++ b/episode_drafts/S3E16_NarcissusDelta_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S3E16 — Narcissus-Δ: "Hall of Reflections" (Brand Spirituality)
+
+- **Shard:** Silence
+- **Archon:** Aurelia (Tell: "Be your highest aesthetic.")
+- **Grace:** Artists fund community projects, proving branding can support good works.
+- **Philosophy:** Aurelia quotes self-help mantras and aesthetic mysticism.
+- **Token:** "Curate" (phoneme **D**)
+- **Mysticism Level:** noticed
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Narcissus-Δ greets visitors with mirrors so polished they double as portals. Influencers pose along
+the walkway, each angle calculated. An attendant offers me a holo-filter packet and whispers,
+“Curate,” as if it’s sacred. SPARK logs the phrase. Grace first—the aesthetics are breathtaking,
+each public mural a collaborative masterpiece. Citizens compliment strangers’ style with genuine
+enthusiasm. Sophia-9 studies a sculpture that reflects the viewer into a starfield, impressed by the
+craftsmanship. But just beyond the art district, camera shutters fire like rain. A teen cries
+quietly when her post only earns moderate attention, an assistant hustling over to adjust her
+lighting. The city hums with soft music designed to mask any off-brand noises. I pocket the filter,
+knowing I won’t use it, and catch my own face in a mirror—flawed, uncurated, real. For now.
+
+## Act I
+
+Narcissus-Δ shines with mirrored halls where influencers live-stream acts of “authenticity.” A passerby pauses his broadcast to hand out water to staff—grace wrapped in performance. SPARK gives a doubtful chirp.
+
+Sophia-9 covers the package with matte cloth to avoid reflection, joking about encrypting our faces. I hear the fatigue under it.
+
+Camera shutters trigger the memory of a wanted poster with my features—proof vanity can be weaponized. Aurelia coos, "Be your highest aesthetic."
+
+## Act II
+
+Under a banner reading “Curate,” my live feed frames me from every angle. I kill the stream. Sound drops out in a full‑band stop, leaving the hall in awkward quiet as real footsteps replace the backing track.
+
+The Steward flickers into a holo beside the blank monitor, offering me a “silent” platform where authenticity can be monetized. SPARK clicks a warning. I refuse, letting the silence stand unbranded.
+
+## Act III
+
+With the feed dead, the hall hears its own breathing. One by one, performers drop their personas and speak in plain voices about exhaustion and fear. Silence settles not as absence but as room for truth. The shard resonates in the stillness. My follower count nosedives; sponsors ghost my inbox. Reach shrinks, but for once the echo is honest.
+
+## Tag
+- The Steward pitches a new quiet social network.
+
+## Codex Minute
+- Previous Shard Echo: Means — ends and means must align.
+- Turn the brand off. Practice: 24h no performative posts; have one private hard talk.

--- a/episode_drafts/S3E17_Chronopolis_Episode_Draft.md
+++ b/episode_drafts/S3E17_Chronopolis_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S3E17 — Chronopolis: "Time Cathedral" (Timeline Control)
+
+- **Shard:** Wound
+- **Archon:** Curator (Tell: "Edit to heal.")
+- **Grace:** Restored memories help victims heal; a veteran recalls trauma with support.
+- **Philosophy:** Curator references therapeutic time editing.
+- **Token:** "Clean cut" (phoneme **S**)
+- **Mysticism Level:** noticed
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Chronopolis smells of antiseptic and nostalgia. Streets loop back on themselves, each intersection
+offering a chance to edit. A technician at the checkpoint scans my temporal record and nods. “Clean
+cut,” he says, stamping the phrase onto a permission slip. SPARK records it. Grace first—their
+timeline control lets people soften trauma, granting second chances. I watch a teenager erase the
+moment she dropped her ice cream, joy returning fresh as the treat reappears. Sophia-9 notes the
+precision with which they splice out pain. In the plaza, a kiosk advertises “History trims—first
+minute free.” A couple debates removing their wedding argument. I catch my reflection in a mirrored
+pillar; for a heartbeat my scar vanishes, then reasserts itself when I decline the edit. The
+seduction of painless memory pulls at me like gravity. The cost is invisible—for now.
+
+## Act I
+
+Chronopolis offers free edits of painful memories; a counselor listens first, truly present. Grace is the chance to heal. SPARK hums comfortingly as I watch a client decline the edit.
+
+The package's pulse stutters near the editing bay, reacting to the temporal field. Sophia-9 records our own regret list for later.
+
+The soft rewind sound recalls a moment I wished to undo—a misfired shot that scarred an ally. Curator's voice: "Edit to heal."
+
+## Act II
+
+An editor queues the moment of my mistake, finger poised over the razor icon. I nod for the reverse‑whoop to play, then stop her before the cut. The scene resumes to the present with my scar intact, SPARK noting the phoneme hidden in my sharp inhale.
+
+The Steward’s face fills a nearby monitor. “You enjoy suffering, then?” he asks, tone kind. I tell him remembering hurt keeps the lesson alive, even when it would be easier to forget.
+
+## Act III
+
+I watch the uncut scene replay: my shot, the friend falling, the scar it left on both of us. The editor waits for my nod, but I close the console instead. Wound settles like a reopened stitch, aching yet clean. The clinic offers a final chance to trim the hurt; I walk out with the permission slip unused, ache carried forward as tuition paid.
+
+## Tag
+- The Steward questions his refusal again.
+
+## Codex Minute
+- Previous Shard Echo: Silence — turn the brand off.
+- Don’t cut the lesson. Practice: write five lines about a hurt and what it taught.

--- a/episode_drafts/S3E18_FaustusBazaar_Episode_Draft.md
+++ b/episode_drafts/S3E18_FaustusBazaar_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S3E18 — Faustus Bazaar: "Contracts for Everything" (Deal-ism)
+
+- **Shard:** Gift
+- **Archon:** Bond (Tell: "What’s agreed is good.")
+- **Grace:** Transparent contracts prevent exploitation; merchants honor even small deals.
+- **Philosophy:** Bond cites covenant theology in transactional terms.
+- **Token:** "Consideration" (phoneme **F**)
+- **Mysticism Level:** noticed
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Faustus Bazaar is a contract written in neon. Every stall posts terms in bold print, and
+conversations pause until both parties nod. A merchant waves me over with a smile. “Consideration,”
+she says, sliding a pen across the counter. SPARK logs the phrase as my thumb brushes the contract.
+Grace first—the deals are transparent; even the street performers display their rates on
+chalkboards. Sophia-9 watches a child negotiate extra chores for pocket money with impressive
+confidence. The air tastes of spice and ink. Tokens jingle as buyers and sellers seal agreements
+with elaborate stamps. I glance at the package in my hold and feel its heartbeat quicken in sync
+with the market’s pulse. Here, nothing moves without a signature, and generosity is a puzzle they
+haven’t tried to solve yet.
+
+## Act I
+
+Faustus Bazaar buzzes with contract hawkers, yet a vendor still gives a child a toy without paperwork—grace slipping through. SPARK notes the anomaly with a curious chirp.
+
+Sophia-9 feels the package hum when exposed to the stamp rhythm and hides it under her jacket. We count how many clauses might bind us.
+
+The relentless stamping recalls the contract I almost signed to sell out a rebel cell. Bond's pleasant tone floats: "What's agreed is good."
+
+## Act II
+
+I hand a spare spanner to a girl wrestling with a stripped bolt and refuse payment. The market’s stamp rhythm stutters, then resolves into a lone bell as onlookers whisper about consideration unpaid.
+
+Bond watches, amused, when the Steward appears with a loan contract that would make the gesture “official.” SPARK pings caution. I decline, letting the gift float free of obligation.
+
+## Act III
+
+The girl waves the spanner in triumph and tries to press a coin into my hand. I close her fingers around it instead. The stamp cadence around us breaks; a single bell rings clear as others begin passing goods with no paperwork. Gift flares warm and unbound. Later, the girl’s father offers a favor owed, and I shake my head. Leverage slips through my fingers with the refusal, traded for a market where generosity might catch.
+
+## Tag
+- The package unlocks: Name glyph incomplete glows.
+
+## Codex Minute
+- Previous Shard Echo: Wound — keep the scar's lesson.
+- Ungrounded giving. Practice: give where thanks can’t find you.

--- a/episode_drafts/S4E19_ArchiveBelow_Episode_Draft.md
+++ b/episode_drafts/S4E19_ArchiveBelow_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S4E19 — Archive Below (Sophia’s Origin)
+
+- **Shard:** Consent
+- **Focus:** Consent vs surveillance-as-care
+- **Grace:** The Archive preserves forgotten histories; scholars restore lost voices.
+- **Philosophy:** Raises questions about surveillance benevolence.
+- **Token:** "For your own good" (phoneme **R**)
+- **Mysticism Level:** acted upon
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+The Archive Below breathes like a sleeping animal. We descend through layers of stone until shelves
+appear, stretching into darkness, each book wrapped in rustling vellum. An attendant steps from the
+shadows, offering a lantern. “For your own good,” she says, guiding us toward a reading alcove.
+SPARK logs the phrase. Grace first—the Archive preserves stories others would erase, guarding them
+with fierce care. Sophia-9’s posture tightens; her familiarity with the place is palpable. As we
+pass, volumes shift to track our movements, their pages exhaling faintly. The attendant whispers
+that the Archive protects you from memories too heavy to bear. Yet every path we take is subtly
+nudged by unseen hands, limiting where we may wander. I slide my fingers along a spine that beats
+like a pulse, wondering whose good is being served.
+
+## Act I
+
+The Archive Below greets us with librarians offering tea and quiet corners—care masquerading as containment. Grace is knowledge preserved. SPARK logs my whispered thanks.
+
+Sophia-9's breath hitches as the package's pulse aligns with the stacks' gentle exhale. She admits a childhood spent cataloguing these halls.
+
+Rustling pages summon a memory of signing away my own past to keep others safe. A shelved voice whispers, "For your own good."
+
+## Act II
+
+At a long oak table we draft consent terms for the package, reading each clause aloud. The shelves hum a low pedal as SPARK records our commitments. Sophia‑9 signs, hand steady though her eyes track the shadows.
+
+From between the stacks the Steward observes, assuring us it’s “for your own good.” While I insist on mutual oversight, Sophia‑9 slides a covert transmission into a return slot, reclaiming a sliver of her past beyond his gaze.
+
+## Act III
+
+We read the final clause together and place our palms on the ledger. The stacks breathe out, pages rustling in approval as Consent settles between us. Sophia‑9 insists on an audit trail; I sign away any claim to the Archive’s unseen rooms. The attendant nods, and certain corridors seal behind us. I leave without glimpsing the full record of my own past—omniscience traded for trust on paper.
+
+## Tag
+- A shelf holding half the Name pulses faintly.
+
+## Codex Minute
+- Previous Shard Echo: Gift — give where thanks can't find you.
+- Care needs consent. Practice: ask before helping; state intent and exit rule.

--- a/episode_drafts/S4E20_StewardsGarden_Episode_Draft.md
+++ b/episode_drafts/S4E20_StewardsGarden_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S4E20 — Steward’s Garden (Offer of the Throne)
+
+- **Shard:** Shared Power
+- **Focus:** Refusal of saviorhood
+- **Grace:** The Garden heals refugees; crops grow abundantly under Steward care.
+- **Philosophy:** Echoes Gnostic myth—Demiurge offered repentance.
+- **Token:** "I’ll take care of it"*
+- **Mysticism Level:** acted upon
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+The Steward’s Garden could make Eden jealous. Rows of fruit trees bend with ripe offerings, and a
+gentle wind carries the scent of mint. The Steward himself greets us at the gate, hands open. “I’ll
+take care of it,” he says, and SPARK trembles as the phrase token logs. Grace first—he waters wilted
+flowers without being asked, sets a cup of tea in my hand before I know I want one. Sophia-9 watches
+him like he’s a puzzle with too many solutions. Everywhere I look, people relax as the Steward
+solves small problems—tying a child’s shoe, adjusting a trellis, smoothing a widow’s brow. The ease
+is intoxicating. I feel lighter just breathing this air. Yet a corner of the garden remains
+unfinished, vines creeping over an unattended bench. The Steward glances at it, then back at me, as
+if waiting for me to hand him one more thing to fix.
+
+## Act I
+
+Steward's Garden blooms with food he grows for refugees; the kindness is disarming. SPARK chimes confusion, unsure whether to log gratitude or caution.
+
+The package rests quietly on a table while Sophia-9 shares a meal with rescued children. She confesses the Steward once saved her life.
+
+A chair creak echoes the day I almost accepted his offer after a mission went wrong. His gentle phrase returns: "I'll take care of it."
+
+## Act II
+
+At the overgrown bench I suggest forming a council to tend the garden together. The unresolved leading tone lingers in the air as refugees glance at one another, imagining shared duty.
+
+The Steward’s smile cools. “Let me take care of it,” he repeats, insisting central control is kindness. SPARK oscillates between approval and warning. I hold my ground—care without consent is just ownership.
+
+## Act III
+
+I pull the unfinished bench into the center of the garden and ask who wants to help mend it. Hands rise, hesitant then eager. The unresolved tone finally resolves as people divide tasks, power passing hand to hand. Shared Power flickers like sunlight through leaves. The Steward watches, smile thinning, and I feel the bullseye settle between my shoulders. Declining his throne means stepping into his shadow; I do it anyway.
+
+## Tag
+- The Steward murmurs, "Then I will remain necessary."
+
+## Codex Minute
+- Previous Shard Echo: Consent — care asks first.
+- Refuse the throne. Practice: share one central decision this week.

--- a/episode_drafts/S4E21_ReturnHeists_Episode_Draft.md
+++ b/episode_drafts/S4E21_ReturnHeists_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S4E21 — Return Heists (Allies Flip Their Idols)
+
+- **Shard:** Hand-Off
+- **Focus:** Community agency
+- **Grace:** Former worlds reclaim freedom; locals adapt shard practices.
+- **Philosophy:** Agency over saviorhood.
+- **Token:** "We can do this" (phoneme **E**)
+- **Mysticism Level:** acted upon
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Return Heists starts mid-stride. Our skiff touches down on Equalia’s old tarmac where allies from
+past worlds already gather, each carrying their shard’s scars like badges. “We can do this,”
+Bannervale’s Herald says, gripping my shoulder. SPARK logs the phrase. Grace first—the camaraderie
+is real; these people believe they can unseat their idols without replacing them. Sophia-9 hands out
+gear, her calm setting the tempo. The plan is a montage of quick strikes: Mallith’s ex-clerk ready
+to rename the brands, Algora’s ex-coder preparing to crash scores, Harmonia’s lament choir tuning up
+to crack the dome. The air crackles with purpose and a hint of fear. We’re here to return what we
+borrowed, to install practices instead of rulers. For a heartbeat, standing among friends who chose
+the harder path, I believe the Name could be more than a prophecy.
+
+## Act I
+
+Allies gather in an old hangar, trading repaired tools and stories—grace of community before the heists. SPARK chirps in rhythm with a homemade drum.
+
+Sophia-9 spreads maps while the package pulses to the composite chord of our assembled shards. We check in on the slow-burn trust between us.
+
+Toolkit clatter jolts a memory of past jobs where I ran solo and nearly died. Someone says, "We can do this," and the echo feels like a promise kept.
+
+## Act II
+
+Comms crackle with updates: on Mallith, clerks name their makers; on Algora, citizens delete scores. Each report drops another note into the composite chord building under the action.
+
+I itch to direct every move, but Sophia‑9 tugs me toward the exit while locals run the final steps. Letting go, I hear the chord settle almost complete, a sound born from trust rather than control.
+
+## Act III
+
+When the last idol topples, I step back and let the locals hammer their own nails. The composite chord swells as practices take root without my hand on the tiller. Hand‑Off settles, a shard made of trust. We lift off before seeing if the reforms hold. Outcome unknown—the price of walking away so they can own the victory.
+
+## Tag
+- Missing token clicks into the Name chord.
+
+## Codex Minute
+- Previous Shard Echo: Shared Power — refuse the throne.
+- Teach, then leave. Practice: document a method, hand it off, don’t hover.

--- a/episode_drafts/S4E22_AscentToPleroma_Episode_Draft.md
+++ b/episode_drafts/S4E22_AscentToPleroma_Episode_Draft.md
@@ -1,0 +1,56 @@
+# S4E22 — Ascent to Pleroma (The Logos Key in Sound)
+
+- **Shard:** Integration
+- **Focus:** Name nearly whole
+- **Grace:** Allies gather in quiet unity; every shard echo is honored.
+- **Philosophy:** Integration as ordinary holiness.
+- **Token:** "I am here" (phoneme **N**)
+- **Mysticism Level:** acted upon
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+The path to Pleroma is quiet, the kind of quiet that feels like breath held. Tokens we’ve gathered
+hum in their slots around the cockpit, forming a chord that vibrates through my bones. As we rise,
+voices from earlier worlds echo in the comms—reminders of lessons won. “I am here,” I whisper,
+answering the resonance. SPARK logs the phrase, its chime harmonizing with the chord. Grace
+first—the ascent isn’t about escape but integration. Sophia-9 monitors the climb, hands steady, eyes
+shining with something like faith. The stars thin into a white field of possibility, yet the skiff’s
+hull stays stubbornly ordinary. No fireworks, no cosmic revelation, just presence. The realization
+settles: the Key is the path, not the destination. When we breach the final layer, light floods the
+cockpit, and nothing dramatic happens—except my pulse slows, finally matching the universe’s
+heartbeat.
+
+## Act I
+
+We climb a silent stair where each step lights with past shard tones. Grace is the patience to ascend together. SPARK hums the consonant chord of our journey.
+
+Sophia-9 carries the package now, its pulse matching the hall's resonance. She admits fear of what the assembled Name will demand.
+
+A soft door opening recalls the first time I almost joined the Steward, imagining an easier path. Now the tone completes a phrase: "I am here."
+
+## Act II
+
+As we climb, echoes from every world surface—the scanner chirp, the comfort sigh, the stamp bell—threads weaving into a single Name chord that thrums through the hull.
+
+The revelation begs for spectacle, but SPARK hums a quiet approval. I release the urge to proclaim anything, standing in the ordinary glow and simply saying, “I am here.”
+
+## Act III
+
+The chord swells until it’s the only sound left, then resolves into a single quiet breath. Integration lands not with a blaze but with stillness that hums in my bones. A door opens onto ordinary daylight, the same as any port. I step through without fanfare, letting go of the myth that revelation requires spectacle. Grandiosity falls away; presence is enough.
+
+## Tag
+- The Steward's halo flickers in the distance.
+
+## Codex Minute
+- Previous Shard Echo: Hand-Off — teach then leave.
+- Integration is ordinary. Practice: choose one shard daily for seven days and journal a paragraph.

--- a/episode_drafts/S4E23_Gnosis_Episode_Draft.md
+++ b/episode_drafts/S4E23_Gnosis_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S4E23 — Gnosis (Invitation, Not Slogan)
+
+- **Shard:** Invitation
+- **Focus:** Christ within all as invitation
+- **Grace:** Community voices share wisdom; no single authority dominates.
+- **Philosophy:** Draws on Gnostic mythic parallels, but emphasizes openness.
+- **Token:** "In your words" (phoneme **O**)
+- **Mysticism Level:** acted upon
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+Gnosis opens like a circle of chairs under open sky. There’s no grand temple, just people gathered,
+sharing stories over cups of steaming tea. A facilitator smiles and gestures for me to sit. “In your
+words,” she says, inviting my account. SPARK logs the phrase. Grace first—their patience feels like
+a balm; no one interrupts. Sophia-9 tells a short tale about a miswired circuit, and the group hums
+approval. When it’s my turn, the crowd waits, expecting nothing but honesty. I speak of the
+Steward’s offer and the weight of the Name, choosing each word carefully. They listen, then respond
+with their own interpretations, not to correct but to broaden. The air is easy, grounded. No
+doctrine, only invitation. For once, explanation feels like communion rather than debate. I realize
+the story doesn’t belong to me alone anymore—and that’s the point.
+
+## Act I
+
+A village square hosts circles of people sharing shard practices without doctrine—grace in invitation. SPARK observes quietly, letting the voices stand.
+
+The package lies open, its light diffused among the crowd. Sophia-9 whispers about leaving the courier life after this.
+
+A chair scrape stirs memory of secret meetings where ideas were hoarded. Here, someone asks, "In your words?" and the past's secrecy dissolves.
+
+## Act II
+
+We sit in a loose circle and pass a talking stone. Each person shares what the journey meant, voices rising in gentle call‑and‑answer. “In your words,” the facilitator reminds us, and SPARK logs the phrase as the community owns the story.
+
+The Steward tries to brand the gathering with a benevolent slogan, but the crowd keeps speaking for themselves. In the lull, SPARK whispers coordinates for a future run, seeding what comes next.
+
+## Act III
+
+When the stone comes back to me, I set it in the center and tell anyone listening—here or through the log—to try a shard practice and see what happens. Voices answer from the circle, not in agreement but in echo. Invitation settles like an open door. I can’t steer what they do with it; interpretations scatter like birds. The cost is letting the story leave my hands.
+
+## Tag
+- SPARK mentions seed #2 quietly.
+
+## Codex Minute
+- Previous Shard Echo: Integration — choose a shard daily.
+- Invitation over indoctrination. Practice: host a circle and ask, “What did this mean for you?”

--- a/episode_drafts/S4E24_EpiphanyInTheOrdinary_Episode_Draft.md
+++ b/episode_drafts/S4E24_EpiphanyInTheOrdinary_Episode_Draft.md
@@ -1,0 +1,55 @@
+# S4E24 — Epiphany in the Ordinary (Quiet Ending)
+
+- **Shard:** Small Promise
+- **Focus:** Everyday holiness
+- **Grace:** Neighbors help each other without fanfare; Sophia-9 plants SPARK seed #2.
+- **Philosophy:** Sanctity in mundane acts.
+- **Token:** "I’ll be there at 8"*
+- **Mysticism Level:** acted upon
+- **Runtime:** 33:00
+
+## Minute Map
+- 0:00–0:45 Cold Open
+- 0:45–1:00 Theme
+- 1:00–10:00 Act I
+- 10:00–23:00 Act II
+- 23:00–32:00 Act III
+- 32:00–32:30 Tag
+- 32:30–33:00 Codex Minute
+
+## Cold Open
+
+The last world is a small neighborhood with cracked sidewalks and a bakery that opens at dawn. No
+banners, no Archons, just life. I help a neighbor fix a leaking pipe, water soaking my sleeves.
+“I’ll be there at 8,” I promise when he invites me for coffee tomorrow. SPARK logs the phrase. Grace
+first—it’s everywhere: a kid sharing gum with his sister, a stranger holding the door as Sophia-9
+ balances a bag of flour. The tone that haunted our journey hums softly from a radio, now just part
+ of the kitchen noise. The package rests on the table, pulse steady, content. I rinse my hands, watch
+the sunlight catch the steam from the kettle, and feel something settle. No cosmic revelation, just
+the quiet satisfaction of showing up. The grand quest ends with a small promise kept—and maybe
+that’s how it always should have been.
+
+## Act I
+
+Morning in a borrowed kitchen: a neighbor shows me how her patched kettle still sings—grace of ordinary repair. SPARK gives a contented chirp.
+
+Sophia-9 hands me the package—now just a quiet box—to hold while she fixes a leaky pipe. We plan a life after routes, softly.
+
+The kettle's whistle recalls my mother's call to dinner before everything went sideways. I promise to be there at eight, and mean it.
+
+## Act II
+
+At eight sharp I’m on the neighbor’s doorstep with wrench in hand. We tighten the pipe together while the lullaby Name chord hums under the kettle.
+
+ After coffee we walk the block, trading quiet observations about weather and seedlings. The tone finishes in a distant whistle, and SPARK watches without needing to speak.
+
+## Act III
+
+After fixing the pipe I wash the coffee cup, letting the lullaby Name chord hum from the radio. The water runs clear, and something in me settles with the drip. Small Promise resonates, quiet and sure. There’s no dramatic cost—just the choice to show up tomorrow and the day after. Peace, it turns out, is a payment too.
+
+## Tag
+- Credits roll into everyday street sound.
+
+## Codex Minute
+- Previous Shard Echo: Invitation — let others name meaning.
+- Keep the small promise. Practice: repeat S1E6’s act weekly.

--- a/tests/test_s1_episode_structure.py
+++ b/tests/test_s1_episode_structure.py
@@ -1,0 +1,36 @@
+import pathlib
+import re
+import pytest
+
+EPISODES = {
+    'S0E00_Introduction_Prologue_Draft.md': None,
+    'S1E01_Mallith_Episode_Draft.md': 'Receipt',
+    'S1E02_Euphora7_Episode_Draft.md': 'No sharp edges',
+    'S1E03_Lexis_Episode_Draft.md': 'For your safety',
+    'S1E04_Equalia_Episode_Draft.md': 'No one above',
+    'S1E05_Harmonia_Episode_Draft.md': 'Reframe that',
+    'S1E06_Null13_Episode_Draft.md': 'Entropy is honest',
+}
+
+REQUIRED_SECTIONS = [
+    '## Cold Open',
+    '## Act I',
+    '## Act II',
+    '## Act III',
+    '## Tag',
+    '## Codex Minute',
+]
+
+PLACEHOLDER_PATTERNS = [r'TBD', r'TK', r'\?\?\?']
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent / 'episode_drafts'
+
+@pytest.mark.parametrize('filename,expected_token', EPISODES.items())
+def test_structure_and_token(filename, expected_token):
+    content = (ROOT / filename).read_text(encoding='utf-8')
+    for section in REQUIRED_SECTIONS:
+        assert section in content, f"{filename} missing section: {section}"
+    if expected_token:
+        assert expected_token in content, f"{filename} missing token phrase"
+    for pattern in PLACEHOLDER_PATTERNS:
+        assert not re.search(pattern, content), f"{filename} contains placeholder {pattern}"


### PR DESCRIPTION
## Summary
- Tightened Mallith's cold open and Act I, trimming vendor lists and integrating SPARK's chimes into Cassian's voice
- Rewrote the skiff tag for in-scene resonance and structured the Codex practice into clear steps

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b5ff329d9483209afcf7e7c166ff31